### PR TITLE
[SELC-7134] Changed jwtPayload map type. Added simple main function to generate tokens without expiration

### DIFF
--- a/libs/cucumber-sdk/pom.xml
+++ b/libs/cucumber-sdk/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>cucumber-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <groupId>it.pagopa.selfcare</groupId>
 
     <distributionManagement>

--- a/libs/cucumber-sdk/src/main/java/it/pagopa/selfcare/cucumber/utils/TestJwtGenerator.java
+++ b/libs/cucumber-sdk/src/main/java/it/pagopa/selfcare/cucumber/utils/TestJwtGenerator.java
@@ -1,12 +1,16 @@
 package it.pagopa.selfcare.cucumber.utils;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import it.pagopa.selfcare.cucumber.utils.model.JwtData;
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -16,8 +20,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -31,13 +34,18 @@ public class TestJwtGenerator {
     }
 
     public String generateToken(JwtData jwtData) {
-        return Optional.ofNullable(jwtData).map(jd ->
-                JWT.create()
-                        .withHeader(jwtData.getJwtHeader())
-                        .withPayload(jwtData.getJwtPayload())
-                        .withIssuedAt(Instant.now())
-                        .withExpiresAt(Instant.now().plusSeconds(3600))
-                        .sign(Algorithm.RSA256(privateKey))
+        return generateToken(jwtData, Instant.now().plusSeconds(3600));
+    }
+
+    public String generateToken(JwtData jwtData, Instant expiresAt) {
+        return Optional.ofNullable(jwtData).map(jd -> {
+                    final JWTCreator.Builder builder = JWT.create()
+                            .withHeader(jwtData.getJwtHeader())
+                            .withPayload(jwtData.getJwtPayload())
+                            .withIssuedAt(Instant.now());
+                    Optional.ofNullable(expiresAt).ifPresent(builder::withExpiresAt);
+                    return builder.sign(Algorithm.RSA256(privateKey));
+                }
         ).orElse(null);
     }
 
@@ -55,4 +63,63 @@ public class TestJwtGenerator {
             return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(keySpec);
         }
     }
+
+    public static void main(String[] args) {
+        try {
+            final TestJwtGenerator jwtGenerator = new TestJwtGenerator();
+            final JwtData jwtData = new JwtData();
+            jwtData.setJwtPayload(new HashMap<>());
+            jwtData.setJwtHeader(new HashMap<>());
+
+            final Scanner scanner = new Scanner(System.in);
+            // FISCAL_NUMBER
+            System.out.print("fiscal_number: ");
+            final String fiscalNumber = scanner.nextLine();
+            jwtData.getJwtPayload().put("fiscal_number", fiscalNumber);
+            // NAME
+            System.out.print("name: ");
+            final String name = scanner.nextLine();
+            jwtData.getJwtPayload().put("name", name);
+            // FAMILY_NAME
+            System.out.print("family_name: ");
+            final String familyName = scanner.nextLine();
+            jwtData.getJwtPayload().put("family_name", familyName);
+            // UID
+            System.out.print("uid (Leave empty to autogenerate one): ");
+            final String uid = scanner.nextLine();
+            jwtData.getJwtPayload().put("uid", uid.isBlank() ? UUID.randomUUID().toString() : uid);
+            // EMAIL
+            System.out.print("email: ");
+            final String email = scanner.nextLine();
+            jwtData.getJwtPayload().put("email", email);
+            // ORGANIZATION
+            System.out.print("organization (json file path): ");
+            final String organizationFilePath = scanner.nextLine();
+            final ObjectReader organizationReader = new ObjectMapper().readerFor(Map.class);
+            final Map<String, String> organization = organizationReader.readValue(new File(organizationFilePath));
+            jwtData.getJwtPayload().put("organization", organization);
+            // AUD
+            System.out.print("aud: ");
+            final String aud = scanner.nextLine();
+            jwtData.getJwtPayload().put("aud", aud);
+            // KID
+            System.out.print("kid: ");
+            final String kid = scanner.nextLine();
+            jwtData.getJwtHeader().put("kid", kid);
+            scanner.close();
+
+            // SPID_LEVEL
+            jwtData.getJwtPayload().put("spid_level", "https://www.spid.gov.it/SpidL2");
+            // ISS
+            jwtData.getJwtPayload().put("iss", "https://selfcare.pagopa.it");
+            // JTI
+            jwtData.getJwtPayload().put("jti", UUID.randomUUID().toString());
+
+            // OUTPUT
+            System.out.println(jwtGenerator.generateToken(jwtData, null));
+        } catch (Exception ex) {
+            System.err.printf("Error generating token: %s%n", ex);
+        }
+    }
+
 }

--- a/libs/cucumber-sdk/src/main/java/it/pagopa/selfcare/cucumber/utils/model/JwtData.java
+++ b/libs/cucumber-sdk/src/main/java/it/pagopa/selfcare/cucumber/utils/model/JwtData.java
@@ -13,6 +13,6 @@ public class JwtData {
     private String password;
 
     private Map<String, Object> jwtHeader;
-    private Map<String, String> jwtPayload;
+    private Map<String, Object> jwtPayload;
 
 }


### PR DESCRIPTION
#### List of Changes

- Changed jwtPayload map type
- Added main function to generate tokens without expiration
- Added new generateToken function to generate tokens with custom expiration

#### Motivation and Context

JWT tokens can also contain integers and map of strings, we align the jwtPayload field type to the jwtHeader one.
The new main method can be used to generate test tokens locally.

#### How Has This Been Tested?

- Local tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.