### PR TITLE
[SELC-8503] feat: added telemetryClient + monitoring dashboard

### DIFF
--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/DocumentMsTelemetryService.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/DocumentMsTelemetryService.java
@@ -1,0 +1,236 @@
+package it.pagopa.selfcare.document.service;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.EventTelemetry;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Centralized service for emitting custom Application Insights events from document-ms.
+ * <p>
+ * Since document-ms is an internal service (not exposed via APIM), the standard opex
+ * dashboard approach used for BFFs is not applicable. This service provides the equivalent
+ * observability via Application Insights custom events, queryable via KQL in Log Analytics.
+ * </p>
+ * Events emitted (queryable via {@code customEvents | where cloud_RoleName == "document-ms"}):
+ * <ul>
+ *   <li>DOCUMENT-MS-PDF-CONTRACT-CREATED</li>
+ *   <li>DOCUMENT-MS-PDF-ATTACHMENT-CREATED</li>
+ *   <li>DOCUMENT-MS-SIGNED-CONTRACT-UPLOADED</li>
+ *   <li>DOCUMENT-MS-SIGNATURE-VERIFIED</li>
+ *   <li>DOCUMENT-MS-SIGNATURE-FAILED</li>
+ *   <li>DOCUMENT-MS-DOCUMENT-SAVED</li>
+ *   <li>DOCUMENT-MS-DOCUMENT-IMPORTED</li>
+ * </ul>
+ */
+@Slf4j
+@ApplicationScoped
+public class DocumentMsTelemetryService {
+
+    static final String EVENT_PDF_CONTRACT_CREATED     = "DOCUMENT-MS-PDF-CONTRACT-CREATED";
+    static final String EVENT_PDF_ATTACHMENT_CREATED   = "DOCUMENT-MS-PDF-ATTACHMENT-CREATED";
+    static final String EVENT_SIGNED_CONTRACT_UPLOADED = "DOCUMENT-MS-SIGNED-CONTRACT-UPLOADED";
+    static final String EVENT_SIGNATURE_VERIFIED       = "DOCUMENT-MS-SIGNATURE-VERIFIED";
+    static final String EVENT_SIGNATURE_FAILED         = "DOCUMENT-MS-SIGNATURE-FAILED";
+    static final String EVENT_DOCUMENT_SAVED           = "DOCUMENT-MS-DOCUMENT-SAVED";
+    static final String EVENT_DOCUMENT_IMPORTED        = "DOCUMENT-MS-DOCUMENT-IMPORTED";
+    static final String EVENT_ATTACHMENT_UPLOADED      = "DOCUMENT-MS-ATTACHMENT-UPLOADED";
+    static final String EVENT_CONTRACT_DELETED         = "DOCUMENT-MS-CONTRACT-DELETED";
+    static final String EVENT_AGGREGATES_CSV_UPLOADED  = "DOCUMENT-MS-AGGREGATES-CSV-UPLOADED";
+    static final String EVENT_VISURA_SAVED             = "DOCUMENT-MS-VISURA-SAVED";
+
+    private final TelemetryClient telemetryClient;
+
+    public DocumentMsTelemetryService() {
+        this.telemetryClient = new TelemetryClient();
+    }
+
+
+    /**
+     * Tracks the successful generation and upload of a contract PDF.
+     *
+     * @param onboardingId onboarding identifier
+     * @param productId    product identifier
+     * @param durationMs   end-to-end duration in milliseconds
+     */
+    public void trackContractPdfCreated(String onboardingId, String productId, long durationMs) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("productId", productId);
+
+        Map<String, Double> metrics = new HashMap<>();
+        metrics.put("durationMs", (double) durationMs);
+
+        track(EVENT_PDF_CONTRACT_CREATED, props, metrics);
+    }
+
+    /**
+     * Tracks the successful generation and upload of an attachment PDF.
+     *
+     * @param onboardingId   onboarding identifier
+     * @param attachmentName attachment name / type
+     * @param durationMs     end-to-end duration in milliseconds
+     */
+    public void trackAttachmentPdfCreated(String onboardingId, String attachmentName, long durationMs) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("attachmentName", attachmentName);
+
+        Map<String, Double> metrics = new HashMap<>();
+        metrics.put("durationMs", (double) durationMs);
+
+        track(EVENT_PDF_ATTACHMENT_CREATED, props, metrics);
+    }
+
+    /**
+     * Tracks the successful upload of a signed contract.
+     *
+     * @param onboardingId onboarding identifier
+     * @param durationMs   end-to-end duration in milliseconds
+     */
+    public void trackSignedContractUploaded(String onboardingId, long durationMs) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+
+        Map<String, Double> metrics = new HashMap<>();
+        metrics.put("durationMs", (double) durationMs);
+
+        track(EVENT_SIGNED_CONTRACT_UPLOADED, props, metrics);
+    }
+
+    /**
+     * Tracks the outcome of a contract signature verification.
+     *
+     * @param onboardingId onboarding identifier
+     * @param success      {@code true} if verification passed, {@code false} if it failed
+     * @param durationMs   duration of the verification in milliseconds
+     */
+    public void trackSignatureVerification(String onboardingId, boolean success, long durationMs) {
+        String eventName = success ? EVENT_SIGNATURE_VERIFIED : EVENT_SIGNATURE_FAILED;
+
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("success", String.valueOf(success));
+
+        Map<String, Double> metrics = new HashMap<>();
+        metrics.put("durationMs", (double) durationMs);
+
+        track(eventName, props, metrics);
+    }
+
+    /**
+     * Tracks the first persistence of a document (contract or attachment) in MongoDB.
+     * Called only when the document does not yet exist in the DB (first save).
+     *
+     * @param onboardingId onboarding identifier
+     * @param documentType document type: INSTITUTION, USER or ATTACHMENT
+     * @param productId    product identifier
+     */
+    public void trackDocumentSaved(String onboardingId, String documentType, String productId) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("documentType", documentType);
+        props.put("productId", productId);
+
+        track(EVENT_DOCUMENT_SAVED, props, new HashMap<>());
+    }
+
+    /**
+     * Tracks the import of a document during a data-import operation.
+     *
+     * @param onboardingId onboarding identifier
+     * @param productId    product identifier
+     */
+    public void trackDocumentImported(String onboardingId, String productId) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("productId", productId);
+
+        track(EVENT_DOCUMENT_IMPORTED, props, new HashMap<>());
+    }
+
+    /**
+     * Tracks the successful upload of an attachment (signed p7m or pdf),
+     * including digest verification and Azure Blob Storage persistence.
+     *
+     * @param onboardingId   onboarding identifier
+     * @param productId      product identifier
+     * @param attachmentName attachment name / type
+     * @param durationMs     end-to-end duration in milliseconds
+     */
+    public void trackAttachmentUploaded(String onboardingId, String productId, String attachmentName, long durationMs) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("productId", productId);
+        props.put("attachmentName", attachmentName);
+
+        Map<String, Double> metrics = new HashMap<>();
+        metrics.put("durationMs", (double) durationMs);
+
+        track(EVENT_ATTACHMENT_UPLOADED, props, metrics);
+    }
+
+    /**
+     * Tracks the deletion (soft-delete / move to delete path) of a contract from Azure Blob Storage.
+     * Critical audit event — contract files are never permanently deleted, only moved.
+     *
+     * @param onboardingId onboarding identifier
+     */
+    public void trackContractDeleted(String onboardingId) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+
+        track(EVENT_CONTRACT_DELETED, props, new HashMap<>());
+    }
+
+    /**
+     * Tracks the successful upload of an aggregates CSV file to Azure Blob Storage.
+     *
+     * @param onboardingId onboarding identifier
+     * @param productId    product identifier
+     */
+    public void trackAggregatesCsvUploaded(String onboardingId, String productId) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("productId", productId);
+
+        track(EVENT_AGGREGATES_CSV_UPLOADED, props, new HashMap<>());
+    }
+
+    /**
+     * Tracks the successful save of a Visura document for a merchant to Azure Blob Storage.
+     *
+     * @param onboardingId onboarding identifier
+     * @param filename     visura filename
+     */
+    public void trackVisuraSaved(String onboardingId, String filename) {
+        Map<String, String> props = new HashMap<>();
+        props.put("onboardingId", onboardingId);
+        props.put("filename", filename);
+
+        track(EVENT_VISURA_SAVED, props, new HashMap<>());
+    }
+
+    // -------------------------------------------------------------------------
+
+    private void track(String eventName, Map<String, String> properties, Map<String, Double> metrics) {
+        try {
+            EventTelemetry telemetry = new EventTelemetry(eventName);
+            telemetry.getProperties().putAll(properties);
+            telemetry.getMetrics().putAll(metrics);
+            telemetryClient.trackEvent(telemetry);
+        } catch (Exception e) {
+            // Telemetry must never affect business logic
+            log.warn("Failed to track telemetry event '{}': {}", eventName, e.getMessage());
+        }
+    }
+}
+
+
+
+
+
+

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
@@ -16,6 +16,7 @@ import it.pagopa.selfcare.document.model.dto.response.CreatePdfResponse;
 import it.pagopa.selfcare.document.model.entity.Document;
 import it.pagopa.selfcare.document.repository.DocumentRepository;
 import it.pagopa.selfcare.document.service.DocumentContentService;
+import it.pagopa.selfcare.document.service.DocumentMsTelemetryService;
 import it.pagopa.selfcare.document.service.DocumentService;
 import it.pagopa.selfcare.document.service.PdfGenerationService;
 import it.pagopa.selfcare.document.service.SignatureService;
@@ -63,7 +64,8 @@ public class DocumentContentServiceImpl implements DocumentContentService {
     private final SignatureService signatureService;
     private final DocumentRepository documentRepository;
     private final DocumentService documentService;
-    private final PdfGenerationService pdfGenerationService; // <-- NUOVA INIECTION
+    private final PdfGenerationService pdfGenerationService;
+    private final DocumentMsTelemetryService telemetryService;
 
     @ConfigProperty(name = "document-ms.blob-storage.path-contracts")
     String pathContracts;
@@ -83,32 +85,45 @@ public class DocumentContentServiceImpl implements DocumentContentService {
             DocumentMsConfig documentMsConfig,
             SignatureService signatureService,
             DocumentRepository documentRepository,
-            DocumentService documentService, PdfGenerationService pdfGenerationService) {
+            DocumentService documentService,
+            PdfGenerationService pdfGenerationService,
+            DocumentMsTelemetryService telemetryService) {
         this.azureBlobClient = azureBlobClient;
         this.documentMsConfig = documentMsConfig;
         this.signatureService = signatureService;
         this.documentRepository = documentRepository;
         this.documentService = documentService;
         this.pdfGenerationService = pdfGenerationService;
+        this.telemetryService = telemetryService;
     }
 
     @Override
     public Uni<CreatePdfResponse> createContractPdf(ContractPdfRequest request) {
         log.info("START - createContractPdf for template: {} with onboardingId: {}",
                 sanitize(request.getContractTemplatePath()), sanitize(request.getOnboardingId()));
+        long start = System.currentTimeMillis();
 
         return buildContractContextAsync(request)
                 .chain(ctx -> signPdfContextAsync(ctx, request))
-                .chain(ctx -> uploadAndBuildResponse(ctx, "contract"));
+                .chain(ctx -> uploadAndBuildResponse(ctx, "contract"))
+                .invoke(response -> telemetryService.trackContractPdfCreated(
+                        request.getOnboardingId(),
+                        request.getProductId(),
+                        System.currentTimeMillis() - start));
     }
 
     @Override
     public Uni<CreatePdfResponse> createAttachmentPdf(AttachmentPdfRequest request) {
         log.info("START - createAttachmentPdf for template: {} with onboardingId: {}",
                 sanitize(request.getAttachmentTemplatePath()), sanitize(request.getOnboardingId()));
+        long start = System.currentTimeMillis();
 
         return buildAttachmentContextAsync(request)
-                .chain(ctx -> uploadAndBuildResponse(ctx, "attachment"));
+                .chain(ctx -> uploadAndBuildResponse(ctx, "attachment"))
+                .invoke(response -> telemetryService.trackAttachmentPdfCreated(
+                        request.getOnboardingId(),
+                        request.getAttachmentName(),
+                        System.currentTimeMillis() - start));
     }
 
     @Override
@@ -176,17 +191,15 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                 sanitize(request.getOnboardingId()),
                 sanitize(request.getProductId()),
                 sanitize(file.getFileName()));
+        long start = System.currentTimeMillis();
 
         return verifyAttachmentDoesNotExist(request)
                 .emitOn(Infrastructure.getDefaultWorkerPool())
                 .chain(() -> {
                     String uploadedDigest = performSecurityValidationsAndGetDigest(request, file);
                     boolean isP7M = DocumentFileUtils.isP7MFile(file.getFileName());
-
-                    // 1. Salvataggio su DB
                     return persistAttachment(request, uploadedDigest, isP7M);
                 })
-                // 2. Upload asincrono su Azure
                 .call(document -> uploadToAzureReactive(document, file)
                         .onFailure().call(azureError -> {
                             log.error("Upload to Azure failed for attachment {}. Rolling back DB record...", sanitize(request.getAttachmentName()));
@@ -194,6 +207,11 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                                     .onFailure().invoke(e -> log.error("CRITICAL: Rollback failed for DB document {}", document.getId(), e));
                         })
                 )
+                .invoke(ignored -> telemetryService.trackAttachmentUploaded(
+                        request.getOnboardingId(),
+                        request.getProductId(),
+                        request.getAttachmentName(),
+                        System.currentTimeMillis() - start))
                 .replaceWithVoid();
     }
 
@@ -228,6 +246,7 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                                 return rollbackDeletedAzureFiles(deletedSignedContract, originalSignedPath, deletedContractFile, originalContractPath);
                             });
                 })
+                .invoke(ignored -> telemetryService.trackContractDeleted(onboardingId))
                 .replaceWith("Contract deleted successfully");
     }
 
@@ -246,7 +265,6 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                         azureBlobClient.uploadFile(path, filename, csvFile.readAllBytes());
                     } catch (IOException e) {
                         log.error("Error reading from file {} ", sanitize(path), e);
-                        // Rilanciamo l'errore per far scattare il Retry
                         throw new RuntimeException("Error during Azure upload", e);
                     }
                 })
@@ -259,6 +277,8 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                             GENERIC_ERROR.getCode(),
                             String.format("Error storing csv aggregate for onboardingId: %s", sanitize(request.getOnboardingId())));
                 })
+                .invoke(ignored -> telemetryService.trackAggregatesCsvUploaded(
+                        request.getOnboardingId(), request.getProductId()))
                 .replaceWithVoid();
     }
 
@@ -299,12 +319,11 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                         azureBlobClient.uploadFile(path, filename, file.readAllBytes());
                     } catch (IOException e) {
                         log.error("Error reading from file {} ", sanitize(path), e);
-                        // Rilanciamo l'errore per far scattare il Retry
                         throw new RuntimeException("Error during Azure upload", e);
                     }
                 })
-                .onFailure().retry().withBackOff(Duration.ofMillis(retryMinBackoff), Duration.ofMillis(retryMaxBackoff)).atMost(retryMaxAttempts)                .onFailure()
-                .transform(e -> {
+                .onFailure().retry().withBackOff(Duration.ofMillis(retryMinBackoff), Duration.ofMillis(retryMaxBackoff)).atMost(retryMaxAttempts)
+                .onFailure().transform(e -> {
                     log.error(
                             "Impossible to store visura document for onboardingId: {}, filename: {}. Error: {}",
                             sanitize(uploadVisuraRequest.getOnboardingId()), sanitize(filename), e.getMessage(), e);
@@ -312,6 +331,8 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                             GENERIC_ERROR.getCode(),
                             String.format("Error storing visura document for onboardingId: %s", sanitize(uploadVisuraRequest.getOnboardingId())));
                 })
+                .invoke(ignored -> telemetryService.trackVisuraSaved(
+                        uploadVisuraRequest.getOnboardingId(), filename))
                 .replaceWithVoid();
     }
 
@@ -321,6 +342,7 @@ public class DocumentContentServiceImpl implements DocumentContentService {
 
     log.info(
         "START - Uploading and verifying signed contract for onboardingId={}, productId={}", sanitize(onboardingId), sanitize(request.getProductId()));
+    long start = System.currentTimeMillis();
 
     return Uni.createFrom()
         .item(
@@ -352,6 +374,8 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                                 request.getFiscalCodes(),
                                 skipSignatureVerification))
                     .chain(document -> uploadToAzureAndUpdateDb(document, physicalFile, fileName))
+                    .invoke(ignored -> telemetryService.trackSignedContractUploaded(
+                            onboardingId, System.currentTimeMillis() - start))
                     .onTermination()
                     .invoke(() -> {
                         physicalFile.delete();

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentServiceImpl.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentServiceImpl.java
@@ -15,6 +15,7 @@ import it.pagopa.selfcare.document.model.dto.response.ContractSignedReport;
 import it.pagopa.selfcare.document.model.entity.Document;
 import it.pagopa.selfcare.document.repository.DocumentRepository;
 import it.pagopa.selfcare.document.service.DocumentService;
+import it.pagopa.selfcare.document.service.DocumentMsTelemetryService;
 import it.pagopa.selfcare.document.service.SignatureService;
 import it.pagopa.selfcare.document.util.DocumentFileUtils;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -40,15 +41,17 @@ public class DocumentServiceImpl implements DocumentService {
     private final DocumentRepository documentRepository;
     private final DocumentMsConfig documentMsConfig;
     private final AzureBlobClient azureBlobClient;
+    private final DocumentMsTelemetryService telemetryService;
 
     @Inject
     SignatureService signatureService;
 
     public DocumentServiceImpl(DocumentRepository documentRepository, DocumentMsConfig documentMsConfig,
-                               AzureBlobClient azureBlobClient) {
+                               AzureBlobClient azureBlobClient, DocumentMsTelemetryService telemetryService) {
         this.documentRepository = documentRepository;
         this.documentMsConfig = documentMsConfig;
         this.azureBlobClient = azureBlobClient;
+        this.telemetryService = telemetryService;
     }
 
     @Override
@@ -171,9 +174,14 @@ public class DocumentServiceImpl implements DocumentService {
 
         return documentRepository.persist(document)
                 .replaceWith(document)
-                .onItem().invoke(() ->
-                        log.info("Document persisted for onboardingId: {}, documentType: {}",
-                                sanitize(request.getOnboardingId()), sanitize(String.valueOf(request.getDocumentType()))));
+                .onItem().invoke(() -> {
+                    log.info("Document persisted for onboardingId: {}, documentType: {}",
+                            sanitize(request.getOnboardingId()), sanitize(String.valueOf(request.getDocumentType())));
+                    telemetryService.trackDocumentSaved(
+                            request.getOnboardingId(),
+                            String.valueOf(request.getDocumentType()),
+                            request.getProductId());
+                });
     }
 
     @Override
@@ -194,8 +202,10 @@ public class DocumentServiceImpl implements DocumentService {
 
         return documentRepository.persist(document)
                 .replaceWith(document)
-                .onItem().invoke(() ->
-                        log.info("Document persisted for onboardingId: {}", sanitize(request.getOnboardingId())));
+                .onItem().invoke(() -> {
+                    log.info("Document persisted for onboardingId: {}", sanitize(request.getOnboardingId()));
+                    telemetryService.trackDocumentImported(request.getOnboardingId(), request.getProductId());
+                });
     }
 
     private Document buildDocument(DocumentBuilderRequest request, String digest) {

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/SignatureServiceImpl.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/SignatureServiceImpl.java
@@ -27,6 +27,7 @@ import it.pagopa.selfcare.document.model.FormItem;
 import it.pagopa.selfcare.document.model.entity.Document;
 import it.pagopa.selfcare.document.service.DocumentService;
 import it.pagopa.selfcare.document.service.SignatureService;
+import it.pagopa.selfcare.document.service.DocumentMsTelemetryService;
 import it.pagopa.selfcare.onboarding.crypto.PadesSignService;
 import it.pagopa.selfcare.onboarding.crypto.entity.SignatureInformation;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -66,13 +67,16 @@ public class SignatureServiceImpl implements SignatureService {
   private final PagoPaSignatureConfig pagoPaSignatureConfig;
   private final TrustedListsCertificateSource trustedListsCertificateSource;
   private final PadesSignService padesSignService;
+  private final DocumentMsTelemetryService telemetryService;
 
   public SignatureServiceImpl(TrustedListsCertificateSource trustedListsCertificateSource,
                               PagoPaSignatureConfig pagoPaSignatureConfig,
-                              PadesSignService padesSignService) {
+                              PadesSignService padesSignService,
+                              DocumentMsTelemetryService telemetryService) {
     this.trustedListsCertificateSource = trustedListsCertificateSource;
     this.pagoPaSignatureConfig = pagoPaSignatureConfig;
     this.padesSignService = padesSignService;
+    this.telemetryService = telemetryService;
   }
 
 
@@ -216,6 +220,7 @@ public class SignatureServiceImpl implements SignatureService {
             return Uni.createFrom().voidItem();
         }
 
+        long start = System.currentTimeMillis();
         return retrieveContractDigest(onboardingId)
                 .onItem()
                 .transformToUni(digest ->
@@ -223,8 +228,11 @@ public class SignatureServiceImpl implements SignatureService {
                                 .voidItem()
                                 .invoke(() -> verifySignature(file, digest, fiscalCodes))
                                 .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-                );
-
+                )
+                .invoke(() -> telemetryService.trackSignatureVerification(
+                        onboardingId, true, System.currentTimeMillis() - start))
+                .onFailure().invoke(err -> telemetryService.trackSignatureVerification(
+                        onboardingId, false, System.currentTimeMillis() - start));
     }
 
     public boolean isSignatureVerificationEnabled() {

--- a/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentContentServiceImplTest.java
+++ b/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentContentServiceImplTest.java
@@ -65,6 +65,7 @@ class DocumentContentServiceImplTest {
     @InjectMock SignatureService signatureService;
     @InjectMock DocumentService documentService;
     @InjectMock DocumentMsConfig documentMsConfig;
+    @InjectMock DocumentMsTelemetryService telemetryService;
     @Inject DocumentContentService documentContentService;
 
     // ---- retrieveContract ----

--- a/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentServiceImplTest.java
+++ b/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentServiceImplTest.java
@@ -54,6 +54,9 @@ class DocumentServiceImplTest {
     @InjectMock
     SignatureService signatureService;
 
+    @InjectMock
+    DocumentMsTelemetryService telemetryService;
+
     // ---- getDocumentsByOnboardingId ----
 
     @Test

--- a/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/SignatureServiceImplTest.java
+++ b/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/SignatureServiceImplTest.java
@@ -60,6 +60,7 @@ class SignatureServiceImplTest {
     private TrustedListsCertificateSource trustedListsCertificateSource;
     private PagoPaSignatureConfig pagoPaSignatureConfig;
     private PadesSignService padesSignService;
+    private DocumentMsTelemetryService telemetryService;
 
     @InjectMock
     DocumentService documentService;
@@ -76,8 +77,9 @@ class SignatureServiceImplTest {
                 .thenReturn(CertificateSourceType.TRUSTED_LIST);
         pagoPaSignatureConfig = Mockito.mock(PagoPaSignatureConfig.class);
         padesSignService = Mockito.mock(PadesSignService.class);
+        telemetryService = Mockito.mock(DocumentMsTelemetryService.class);
 
-        service = new SignatureServiceImpl(trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService);
+        service = new SignatureServiceImpl(trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService, telemetryService);
         setField(service, "isVerifyEnabled", Boolean.TRUE);
         setField(service, "documentService", documentService);
     }
@@ -144,6 +146,18 @@ class SignatureServiceImplTest {
         File file = tempDir.resolve("test-" + System.nanoTime() + ".pdf").toFile();
         Files.writeString(file.toPath(), content);
         return file;
+    }
+
+    /**
+     * Creates a spy of SignatureServiceImpl with all required dependencies,
+     * including the telemetryService mock added after the refactoring.
+     */
+    private SignatureServiceImpl createSpyService() {
+        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
+                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService, telemetryService));
+        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
+        setField(spyService, "documentService", documentService);
+        return spyService;
     }
 
     private DSSDocument createMockDocWithDigest(String digestValue) {
@@ -889,10 +903,7 @@ class SignatureServiceImplTest {
                     .thenReturn(mockValidator);
 
             // Create spy to control extractPdfFromSignedContainer and computeDigestOfSignedRevision
-            SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                    trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-            setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-            setField(spyService, "documentService", documentService);
+            SignatureServiceImpl spyService = createSpyService();
 
             doReturn(mockDocument).when(spyService).extractPdfFromSignedContainer(any(), any());
             doReturn(templateDigest).when(spyService).computeDigestOfSignedRevision(any(), any());
@@ -923,10 +934,7 @@ class SignatureServiceImplTest {
             validatorMock.when(() -> SignedDocumentValidator.fromDocument(any(DSSDocument.class)))
                     .thenReturn(mockValidator);
 
-            SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                    trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-            setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-            setField(spyService, "documentService", documentService);
+            SignatureServiceImpl spyService = createSpyService();
 
             doReturn(mockDocument).when(spyService).extractPdfFromSignedContainer(any(), any());
             doReturn(uploadedDigest).when(spyService).computeDigestOfSignedRevision(any(), any());
@@ -956,10 +964,7 @@ class SignatureServiceImplTest {
             validatorMock.when(() -> SignedDocumentValidator.fromDocument(any(DSSDocument.class)))
                     .thenReturn(mockValidator);
 
-            SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                    trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-            setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-            setField(spyService, "documentService", documentService);
+            SignatureServiceImpl spyService = createSpyService();
 
             doReturn(mockDocument).when(spyService).extractPdfFromSignedContainer(any(), any());
             doReturn(uploadedDigest).when(spyService).computeDigestOfSignedRevision(any(), any());
@@ -996,10 +1001,7 @@ class SignatureServiceImplTest {
             validatorMock.when(() -> SignedDocumentValidator.fromDocument(any(DSSDocument.class)))
                     .thenReturn(mockValidator);
 
-            SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                    trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-            setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-            setField(spyService, "documentService", documentService);
+            SignatureServiceImpl spyService = createSpyService();
 
             // Don't mock internal methods - let them run to cover lines 427-448
             // But we need to mock the static validator creation
@@ -1132,10 +1134,7 @@ class SignatureServiceImplTest {
 
     @Test
     void verifySignatureFile_shouldReturnTrueWhenFullValidationChainPasses() throws IOException {
-        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-        setField(spyService, "documentService", documentService);
+        SignatureServiceImpl spyService = createSpyService();
 
         File testFile = createTempFile("valid-content");
 
@@ -1194,10 +1193,7 @@ class SignatureServiceImplTest {
     @Test
     void verifySignatureFileChecksumTaxCode_shouldExecuteFullValidationChain() throws IOException {
         // Arrange: create spy to mock createDocumentValidator
-        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-        setField(spyService, "documentService", documentService);
+        SignatureServiceImpl spyService = createSpyService();
 
         File testFile = createTempFile("test-content");
         String checksum = "correctChecksum";
@@ -1243,10 +1239,7 @@ class SignatureServiceImplTest {
     @Test
     void verifySignatureFileChecksumTaxCode_shouldThrowWhenSignatureFormInvalid() throws IOException {
         // Arrange: create spy to mock createDocumentValidator
-        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-        setField(spyService, "documentService", documentService);
+        SignatureServiceImpl spyService = createSpyService();
 
         File testFile = createTempFile("test-content");
         String checksum = "correctChecksum";
@@ -1277,10 +1270,7 @@ class SignatureServiceImplTest {
     @Test
     void verifySignatureFileChecksumTaxCode_shouldThrowWhenDigestMismatch() throws IOException {
         // Arrange: create spy
-        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-        setField(spyService, "documentService", documentService);
+        SignatureServiceImpl spyService = createSpyService();
 
         File testFile = createTempFile("test-content");
         String expectedChecksum = "expectedChecksum";
@@ -1317,10 +1307,7 @@ class SignatureServiceImplTest {
     @Test
     void verifySignatureFileChecksumTaxCode_shouldThrowWhenTaxCodeMismatch() throws IOException {
         // Arrange: create spy
-        SignatureServiceImpl spyService = spy(new SignatureServiceImpl(
-                trustedListsCertificateSource, pagoPaSignatureConfig, padesSignService));
-        setField(spyService, "isVerifyEnabled", Boolean.TRUE);
-        setField(spyService, "documentService", documentService);
+        SignatureServiceImpl spyService = createSpyService();
 
         File testFile = createTempFile("test-content");
         String checksum = "correctChecksum";

--- a/infra/dashboards/document-ms-dashboard.json
+++ b/infra/dashboards/document-ms-dashboard.json
@@ -1,0 +1,682 @@
+{
+  "lenses": {
+    "0": {
+      "order": 0,
+      "parts": {
+        "0": {
+          "position": {
+            "x": 0,
+            "y": 0,
+            "colSpan": 9,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize Count = count() by bin(timestamp, 1h)\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [{ "name": "Count", "type": "long" }],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "HTTP Requests (document-ms)"
+              }
+            }
+          }
+        },
+        "1": {
+          "position": {
+            "x": 9,
+            "y": 0,
+            "colSpan": 7,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "b2c3d4e5-f6a7-8901-bcde-f12345678901", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize Failures = countif(success == false), Total = count() by bin(timestamp, 1h)\n| extend FailureRate = round(todouble(Failures) / todouble(Total) * 100, 2)\n| project timestamp, FailureRate\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [{ "name": "FailureRate", "type": "real" }],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Failure Rate % (document-ms)"
+              }
+            }
+          }
+        },
+        "2": {
+          "position": {
+            "x": 0,
+            "y": 4,
+            "colSpan": 9,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "c3d4e5f6-a7b8-9012-cdef-123456789012", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize p50 = percentile(duration, 50), p95 = percentile(duration, 95) by bin(timestamp, 1h)\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [
+                    { "name": "p50", "type": "real" },
+                    { "name": "p95", "type": "real" }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Response Time p50 / p95 ms (document-ms)"
+              }
+            }
+          }
+        },
+        "3": {
+          "position": {
+            "x": 9,
+            "y": 4,
+            "colSpan": 7,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "d4e5f6a7-b8c9-0123-def0-234567890123", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "exceptions\n| where cloud_RoleName == \"document-ms\"\n| summarize Count = count() by type, outerMessage\n| order by Count desc\n| take 20\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "AnalyticsGrid", "isOptional": true },
+              { "name": "SpecificChart", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              { "name": "Dimensions", "isOptional": true },
+              { "name": "LegendOptions", "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Top Exceptions (document-ms)"
+              }
+            }
+          }
+        },
+        "4": {
+          "position": {
+            "x": 0,
+            "y": 8,
+            "colSpan": 8,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "e5f6a7b8-c9d0-1234-ef01-345678901234", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| where name contains \"document-content\"\n| summarize Count = count() by bin(timestamp, 1h), name\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [{ "name": "Count", "type": "long" }],
+                  "splitBy": [{ "name": "name", "type": "string" }],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "PDF Generation Requests - Contract & Attachment (document-ms)"
+              }
+            }
+          }
+        },
+        "5": {
+          "position": {
+            "x": 8,
+            "y": 8,
+            "colSpan": 8,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "f6a7b8c9-d0e1-2345-f012-456789012345", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| where name contains \"signature\" or name contains \"upload-signed-contract\"\n| summarize Count = count() by bin(timestamp, 1h), name\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [{ "name": "Count", "type": "long" }],
+                  "splitBy": [{ "name": "name", "type": "string" }],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Signature & Upload Signed Contract Requests (document-ms)"
+              }
+            }
+          }
+        },
+        "6": {
+          "position": {
+            "x": 0,
+            "y": 12,
+            "colSpan": 8,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "a7b8c9d0-e1f2-3456-0123-567890123456", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize Count = count(), AvgDuration = round(avg(duration), 2), FailCount = countif(success == false) by name\n| order by Count desc\n| take 15\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "AnalyticsGrid", "isOptional": true },
+              { "name": "SpecificChart", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              { "name": "Dimensions", "isOptional": true },
+              { "name": "LegendOptions", "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Top Endpoints by Traffic (document-ms)"
+              }
+            }
+          }
+        },
+        "7": {
+          "position": {
+            "x": 8,
+            "y": 12,
+            "colSpan": 8,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "b8c9d0e1-f2a3-4567-1234-678901234567", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| where success == false\n| order by timestamp desc\n| project timestamp, name, resultCode, duration\n| take 50\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "AnalyticsGrid", "isOptional": true },
+              { "name": "SpecificChart", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              { "name": "Dimensions", "isOptional": true },
+              { "name": "LegendOptions", "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "GridColumnsWidth": {
+                  "name": "300px",
+                  "resultCode": "80px",
+                  "duration": "100px"
+                },
+                "PartTitle": "Recent Failed Requests (document-ms)"
+              }
+            }
+          }
+        },
+        "8": {
+          "position": {
+            "x": 0,
+            "y": 16,
+            "colSpan": 9,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "c9d0e1f2-a3b4-5678-2345-789012345678", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "customEvents\n| where cloud_RoleName == \"document-ms\"\n| where name in (\n    \"DOCUMENT-MS-PDF-CONTRACT-CREATED\",\n    \"DOCUMENT-MS-PDF-ATTACHMENT-CREATED\",\n    \"DOCUMENT-MS-SIGNED-CONTRACT-UPLOADED\",\n    \"DOCUMENT-MS-SIGNATURE-VERIFIED\",\n    \"DOCUMENT-MS-SIGNATURE-FAILED\"\n  )\n| summarize Count = count() by name, bin(timestamp, 1h)\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [{ "name": "Count", "type": "long" }],
+                  "splitBy": [{ "name": "name", "type": "string" }],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Custom Business Events nel tempo (document-ms)"
+              }
+            }
+          }
+        },
+        "9": {
+          "position": {
+            "x": 9,
+            "y": 16,
+            "colSpan": 7,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "d0e1f2a3-b4c5-6789-3456-890123456789", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P1D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "customEvents\n| where cloud_RoleName == \"document-ms\"\n| where name in (\n    \"DOCUMENT-MS-PDF-CONTRACT-CREATED\",\n    \"DOCUMENT-MS-PDF-ATTACHMENT-CREATED\",\n    \"DOCUMENT-MS-SIGNED-CONTRACT-UPLOADED\",\n    \"DOCUMENT-MS-SIGNATURE-VERIFIED\",\n    \"DOCUMENT-MS-SIGNATURE-FAILED\"\n  )\n| extend props = parse_json(tostring(customDimensions))\n| extend onboardingId = tostring(props[\"onboardingId\"]), durationMs = todouble(customMeasurements[\"durationMs\"])\n| order by timestamp desc\n| project timestamp, name, onboardingId, durationMs\n| take 50\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "AnalyticsGrid", "isOptional": true },
+              { "name": "SpecificChart", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              { "name": "Dimensions", "isOptional": true },
+              { "name": "LegendOptions", "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "GridColumnsWidth": {
+                  "name": "280px",
+                  "onboardingId": "220px",
+                  "durationMs": "100px"
+                },
+                "PartTitle": "Custom Events recenti con durata (document-ms)"
+              }
+            }
+          }
+        },
+        "10": {
+          "position": {
+            "x": 0,
+            "y": 20,
+            "colSpan": 9,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "e1f2a3b4-c5d6-7890-4567-901234567890", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P7D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize RequestsPerHour = count(), P95DurationMs = percentile(duration, 95) by bin(timestamp, 1h)\n| order by timestamp asc\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "FrameControlChart", "isOptional": true },
+              { "name": "SpecificChart", "value": "Line", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              {
+                "name": "Dimensions",
+                "value": {
+                  "xAxis": { "name": "timestamp", "type": "datetime" },
+                  "yAxis": [
+                    { "name": "RequestsPerHour", "type": "long" },
+                    { "name": "P95DurationMs", "type": "real" }
+                  ],
+                  "splitBy": [],
+                  "aggregation": "Sum"
+                },
+                "isOptional": true
+              },
+              { "name": "LegendOptions", "value": { "isEnabled": true, "position": "Bottom" }, "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Throughput/ora vs P95 — Supporto dimensionamento istanze (document-ms)"
+              }
+            }
+          }
+        },
+        "11": {
+          "position": {
+            "x": 9,
+            "y": 20,
+            "colSpan": 7,
+            "rowSpan": 4
+          },
+          "metadata": {
+            "inputs": [
+              { "name": "resourceTypeMode", "isOptional": true },
+              { "name": "ComponentId", "isOptional": true },
+              {
+                "name": "Scope",
+                "value": {
+                  "resourceIds": [
+                    "/subscriptions/${subscription_id}/resourceGroups/${prefix}-monitor-rg/providers/microsoft.insights/components/${prefix}-appinsights"
+                  ]
+                },
+                "isOptional": true
+              },
+              { "name": "PartId", "value": "f2a3b4c5-d6e7-8901-5678-012345678901", "isOptional": true },
+              { "name": "Version", "value": "2.0", "isOptional": true },
+              { "name": "TimeRange", "value": "P7D", "isOptional": true },
+              { "name": "DashboardId", "isOptional": true },
+              { "name": "DraftRequestParameters", "isOptional": true },
+              {
+                "name": "Query",
+                "value": "requests\n| where cloud_RoleName == \"document-ms\"\n| summarize RequestsPerHour = count() by bin(timestamp, 1h)\n| summarize MaxLoad = max(RequestsPerHour), AvgLoad = avg(RequestsPerHour), P95Load = percentile(RequestsPerHour, 95)\n",
+                "isOptional": true
+              },
+              { "name": "ControlType", "value": "AnalyticsGrid", "isOptional": true },
+              { "name": "SpecificChart", "isOptional": true },
+              { "name": "PartTitle", "value": "Analytics", "isOptional": true },
+              { "name": "PartSubTitle", "value": "${prefix}-appinsights", "isOptional": true },
+              { "name": "Dimensions", "isOptional": true },
+              { "name": "LegendOptions", "isOptional": true },
+              { "name": "IsQueryContainTimeRange", "value": false, "isOptional": true }
+            ],
+            "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            "settings": {
+              "content": {
+                "PartTitle": "Picco / Media / P95 richieste/ora — Dimensionamento (document-ms)"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "metadata": {
+    "model": {
+      "timeRange": {
+        "value": {
+          "relative": {
+            "duration": 24,
+            "timeUnit": 1
+          }
+        },
+        "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+      },
+      "filterLocale": {
+        "value": "en-us"
+      },
+      "filters": {
+        "value": {
+          "MsPortalFx_TimeRange": {
+            "model": {
+              "format": "utc",
+              "granularity": "auto",
+              "relative": "24h"
+            },
+            "displayCache": {
+              "name": "UTC Time",
+              "value": "Past 24 hours"
+            },
+            "filteredPartIds": [
+              "StartboardPart-LogsDashboardPart-document-ms-00",
+              "StartboardPart-LogsDashboardPart-document-ms-01",
+              "StartboardPart-LogsDashboardPart-document-ms-02",
+              "StartboardPart-LogsDashboardPart-document-ms-03",
+              "StartboardPart-LogsDashboardPart-document-ms-04",
+              "StartboardPart-LogsDashboardPart-document-ms-05",
+              "StartboardPart-LogsDashboardPart-document-ms-06",
+              "StartboardPart-LogsDashboardPart-document-ms-07"
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/infra/dashboards/monitor.tf
+++ b/infra/dashboards/monitor.tf
@@ -17,3 +17,16 @@ resource "azurerm_portal_dashboard" "monitoring_onboarding_event" {
       prefix          = "${var.prefix}-${var.env_short}"
   })
 }
+
+resource "azurerm_portal_dashboard" "monitoring_document_ms" {
+  name                = "${local.project}-monitoring-document-ms"
+  resource_group_name = azurerm_resource_group.monitor_rg.name
+  location            = azurerm_resource_group.monitor_rg.location
+  tags                = var.tags
+
+  dashboard_properties = templatefile("document-ms-dashboard.json",
+    {
+      subscription_id = data.azurerm_subscription.current.subscription_id
+      prefix          = "${var.prefix}-${var.env_short}"
+  })
+}


### PR DESCRIPTION
#### List of Changes

**Terraform — Azure Portal Dashboard**
- Added `infra/dashboards/document-ms-dashboard.json`: new dashboard template with 11 tiles covering HTTP traffic, failure rate, response time (p50/p95), top exceptions, PDF generation operations, signature operations, top endpoints by traffic, recent failed requests, custom business events over time, custom events detail with duration, and throughput/hour vs p95 for instance sizing support
- Updated `infra/dashboards/monitor.tf`: added `azurerm_portal_dashboard.monitoring_document_ms` resource deploying the dashboard on all environments (dev/uat/prod)

**Java — Custom Telemetry Service**
- Added `DocumentMsTelemetryService.java`: new CDI `@ApplicationScoped` bean wrapping `TelemetryClient` (already available via `applicationinsights-web:2.6.4`) to emit 11 structured custom events to Application Insights

**Java — Telemetry integration in services**

| Service | Events added |
|---------|-------------|
| `DocumentContentServiceImpl` | `DOCUMENT-MS-PDF-CONTRACT-CREATED`, `DOCUMENT-MS-PDF-ATTACHMENT-CREATED`, `DOCUMENT-MS-SIGNED-CONTRACT-UPLOADED`, `DOCUMENT-MS-ATTACHMENT-UPLOADED`, `DOCUMENT-MS-CONTRACT-DELETED`, `DOCUMENT-MS-AGGREGATES-CSV-UPLOADED`, `DOCUMENT-MS-VISURA-SAVED` |
| `DocumentServiceImpl` | `DOCUMENT-MS-DOCUMENT-SAVED`, `DOCUMENT-MS-DOCUMENT-IMPORTED` |
| `SignatureServiceImpl` | `DOCUMENT-MS-SIGNATURE-VERIFIED`, `DOCUMENT-MS-SIGNATURE-FAILED` |

Each event carries contextual properties (`onboardingId`, `productId`, `documentType`, etc.) and, where applicable, a `durationMs` measurement for end-to-end timing.

**Tests — constructor alignment**
- `SignatureServiceImplTest`: added `telemetryService` mock field, initialised in `@BeforeEach`, extracted `createSpyService()` helper to centralise the 9 recurring `spy(new SignatureServiceImpl(...))` instantiations
- `DocumentServiceImplTest`: added `@InjectMock DocumentMsTelemetryService telemetryService`
- `DocumentContentServiceImplTest`: added `@InjectMock DocumentMsTelemetryService telemetryService`

---

#### Motivation and Context

`document-ms` is an **internal service** not exposed via APIM, so the standard `opex.dashboard` approach used for BFFs (which relies on gateway-level API metrics) is not applicable.

This PR introduces the equivalent observability layer via **Application Insights custom events**, following the same infrastructure already in place (the service already ships `applicationinsights-agent.jar` and `APPLICATIONINSIGHTS_CONNECTION_STRING`). Custom events allow querying business-level scenarios via KQL on the shared Log Analytics Workspace, answering questions such as:
- How many contract PDFs are generated per day/product?
- How many signature verifications fail vs succeed?
- How long does each operation take end-to-end?
- When was a contract soft-deleted, and for which onboarding?

The dashboard also includes two tiles (throughput/hour vs p95 latency over 7 days, and peak/average/p95 requests-per-hour) to support informed decisions on `min_replicas`/`max_replicas` and scale rule configuration.

---

#### How Has This Been Tested?

- Existing unit tests for all three modified services pass without changes to test logic; only constructor signatures were aligned by injecting the `DocumentMsTelemetryService` mock
- `DocumentMsTelemetryService` wraps all `TelemetryClient` calls in a `try/catch` — verified that a failure in telemetry does **not** propagate to business logic
- The Terraform dashboard template uses the same `templatefile()` pattern as the existing `monitoring.json` dashboard and was validated locally with `terraform plan` against dev-ar
- KQL queries in the dashboard were manually verified against the Application Insights schema (`requests`, `exceptions`, `customEvents` tables)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.