### PR TITLE
[SELC-8481] feat: (CED) Add external-v2 tags and update status handling for onboarding 

### DIFF
--- a/apps/onboarding-bff/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/apps/onboarding-bff/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -209,7 +209,7 @@
     },
     "/v1/onboarding" : {
       "get" : {
-        "tags" : [ "Onboarding Controller" ],
+        "tags" : [ "Onboarding Controller", "external-v2" ],
         "summary" : "Retrieve paged onboardings with optional filters and sorting.",
         "description" : "The API retrieves paged onboarding using optional filter, order by descending creation date",
         "operationId" : "getOnboardingWithFilter",
@@ -272,7 +272,7 @@
           "name" : "status",
           "in" : "query",
           "schema" : {
-            "type" : "string"
+            "$ref" : "#/components/schemas/OnboardingStatus"
           }
         }, {
           "name" : "subunitCode",
@@ -1291,7 +1291,7 @@
         } ]
       },
       "delete" : {
-        "tags" : [ "internal-v1" ],
+        "tags" : [ "internal-v1", "external-v2" ],
         "summary" : "Perform delete operation of an onboarding request",
         "description" : "Perform delete operation of an onboarding request receiving onboarding id, then invokes async process to set DELETED as status for institution and user onboardings.",
         "operationId" : "deleteOnboarding",
@@ -1357,7 +1357,7 @@
     },
     "/v1/onboarding/{onboardingId}/complete" : {
       "put" : {
-        "tags" : [ "internal-v1" ],
+        "tags" : [ "internal-v1", "external-v2" ],
         "summary" : "Complete onboarding by verifying and uploading contract, then trigger async activities.",
         "description" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
         "operationId" : "completeOnboardingUsingPUT",
@@ -1581,7 +1581,7 @@
     },
     "/v1/onboarding/{onboardingId}/reject" : {
       "put" : {
-        "tags" : [ "Onboarding Controller" ],
+        "tags" : [ "Onboarding Controller", "external-v2" ],
         "summary" : "Perform reject operation of an onboarding request",
         "description" : "Perform reject operation of an onboarding request receiving onboarding id.Function change status to REJECT for an onboarding request that is not COMPLETED. ",
         "operationId" : "delete",

--- a/apps/onboarding-bff/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/apps/onboarding-bff/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -209,7 +209,7 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
                 null,
                 null,
                 null,
-                status,
+                OnboardingStatus.fromValue(status),
                 null,
                 taxCode,
                 null,

--- a/apps/onboarding-bff/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/apps/onboarding-bff/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -649,7 +649,7 @@ class OnboardingMsConnectorImplTest {
     void onboardingWithFilterTest() {
         // Given
         final String taxCode = "taxCode";
-        final String status = "status";
+        final String status = "COMPLETED";
 
         OnboardingGet onboardingGet = new OnboardingGet();
         onboardingGet.setProductId("prod-test");

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -209,7 +209,7 @@
     },
     "/v1/onboarding" : {
       "get" : {
-        "tags" : [ "Onboarding Controller" ],
+        "tags" : [ "Onboarding Controller", "external-v2" ],
         "summary" : "Retrieve paged onboardings with optional filters and sorting.",
         "description" : "The API retrieves paged onboarding using optional filter, order by descending creation date",
         "operationId" : "getOnboardingWithFilter",
@@ -272,7 +272,7 @@
           "name" : "status",
           "in" : "query",
           "schema" : {
-            "type" : "string"
+            "$ref" : "#/components/schemas/OnboardingStatus"
           }
         }, {
           "name" : "subunitCode",
@@ -1291,7 +1291,7 @@
         } ]
       },
       "delete" : {
-        "tags" : [ "internal-v1" ],
+        "tags" : [ "internal-v1", "external-v2" ],
         "summary" : "Perform delete operation of an onboarding request",
         "description" : "Perform delete operation of an onboarding request receiving onboarding id, then invokes async process to set DELETED as status for institution and user onboardings.",
         "operationId" : "deleteOnboarding",
@@ -1357,7 +1357,7 @@
     },
     "/v1/onboarding/{onboardingId}/complete" : {
       "put" : {
-        "tags" : [ "internal-v1" ],
+        "tags" : [ "internal-v1", "external-v2" ],
         "summary" : "Complete onboarding by verifying and uploading contract, then trigger async activities.",
         "description" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
         "operationId" : "completeOnboardingUsingPUT",
@@ -1581,7 +1581,7 @@
     },
     "/v1/onboarding/{onboardingId}/reject" : {
       "put" : {
-        "tags" : [ "Onboarding Controller" ],
+        "tags" : [ "external-v2", "Onboarding Controller" ],
         "summary" : "Perform reject operation of an onboarding request",
         "description" : "Perform reject operation of an onboarding request receiving onboarding id.Function change status to REJECT for an onboarding request that is not COMPLETED. ",
         "operationId" : "delete",

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -153,6 +153,7 @@ paths:
     get:
       tags:
       - Onboarding Controller
+      - external-v2
       summary: Retrieve paged onboardings with optional filters and sorting.
       description: "The API retrieves paged onboarding using optional filter, order\
         \ by descending creation date"
@@ -199,7 +200,7 @@ paths:
       - name: status
         in: query
         schema:
-          type: string
+          $ref: "#/components/schemas/OnboardingStatus"
       - name: subunitCode
         in: query
         schema:
@@ -934,6 +935,7 @@ paths:
     delete:
       tags:
       - internal-v1
+      - external-v2
       summary: Perform delete operation of an onboarding request
       description: "Perform delete operation of an onboarding request receiving onboarding\
         \ id, then invokes async process to set DELETED as status for institution\
@@ -986,6 +988,7 @@ paths:
     put:
       tags:
       - internal-v1
+      - external-v2
       summary: "Complete onboarding by verifying and uploading contract, then trigger\
         \ async activities."
       description: "Perform complete operation of an onboarding request receiving\
@@ -1163,6 +1166,7 @@ paths:
   /v1/onboarding/{onboardingId}/reject:
     put:
       tags:
+      - external-v2
       - Onboarding Controller
       summary: Perform reject operation of an onboarding request
       description: 'Perform reject operation of an onboarding request receiving onboarding

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -333,6 +333,7 @@ public class OnboardingController {
     @PUT
     @Path("/{onboardingId}/complete")
     @Tag(name = "internal-v1")
+    @Tag(name = "external-v2")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Uni<Response> complete(@PathParam(value = "onboardingId") String onboardingId, @NotNull @RestForm("contract") File file, @Context ResteasyReactiveRequestContext ctx) {
         return onboardingService.complete(onboardingId, retrieveContractFromFormData(ctx.getFormData(), file))
@@ -398,6 +399,8 @@ public class OnboardingController {
     )
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = "Onboarding Controller")
+    @Tag(name = "external-v2")
     public Uni<OnboardingGetResponse> getOnboardingWithFilter(@QueryParam(value = "productId") String productId,
                                                               @QueryParam(value = "taxCode") String taxCode,
                                                               @QueryParam(value = "institutionId") String institutionId,
@@ -405,7 +408,7 @@ public class OnboardingController {
                                                               @QueryParam(value = "subunitCode") String subunitCode,
                                                               @QueryParam(value = "from") String from,
                                                               @QueryParam(value = "to") String to,
-                                                              @QueryParam(value = "status") String status,
+                                                              @QueryParam(value = "status") OnboardingStatus status,
                                                               @QueryParam(value = "userId") String userId,
                                                               @QueryParam(value = "productIds") List<String> productIds,
                                                               @QueryParam(value = "page") @DefaultValue("0") Integer page,
@@ -433,6 +436,8 @@ public class OnboardingController {
             description = "Perform reject operation of an onboarding request receiving onboarding id." +
                     "Function change status to REJECT for an onboarding request that is not COMPLETED. ")
     @PUT
+    @Tag(name = "external-v2")
+    @Tag(name = "Onboarding Controller")
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{onboardingId}/reject")
     public Uni<Response> delete(@PathParam(value = "onboardingId") String onboardingId, @Valid ReasonRequest reason) {
@@ -488,7 +493,7 @@ public class OnboardingController {
     @Tag(name = "Onboarding")
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/institutionOnboardings")
-    public Uni<List<OnboardingResponse>> getOnboardingPending(@QueryParam(value = "taxCode") String taxCode,
+    public Uni<List<OnboardingResponse>> getOnboardings(@QueryParam(value = "taxCode") String taxCode,
                                                               @QueryParam(value = "subunitCode") String subunitCode,
                                                               @QueryParam(value = "origin") String origin,
                                                               @QueryParam(value = "originId") String originId,
@@ -664,6 +669,7 @@ public class OnboardingController {
                     "then invokes async process to set DELETED as status for institution and user onboardings.")
     @DELETE
     @Tag(name = "internal-v1")
+    @Tag(name = "external-v2")
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{onboardingId}")
     public Uni<Response> deleteOnboarding(@PathParam(value = "onboardingId") String onboardingId) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/model/OnboardingGetFilters.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/model/OnboardingGetFilters.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.model;
 
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,7 +17,7 @@ public class OnboardingGetFilters {
     private String onboardingId;
     private String subunitCode;
     private String taxCode;
-    private String status;
+    private OnboardingStatus status;
     private String from;
     private String to;
     private String userId;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -85,7 +85,7 @@ public class QueryUtils {
     Optional.ofNullable(filters.getProductId()).ifPresent(value -> queryParameterMap.put(PRODUCT, value));
     Optional.ofNullable(filters.getTaxCode()).ifPresent(value -> queryParameterMap.put(INSTITUTION_TAX_CODE, value));
     Optional.ofNullable(filters.getSubunitCode()).ifPresent(value -> queryParameterMap.put(INSTITUTION_SUBUNIT_CODE, value));
-    Optional.ofNullable(filters.getStatus()).ifPresent(value -> queryParameterMap.put(STATUS, value));
+    Optional.ofNullable(filters.getStatus()).ifPresent(value -> queryParameterMap.put(STATUS, value.name()));
     Optional.ofNullable(filters.getFrom()).ifPresent(value -> queryParameterMap.put(FROM, value));
     Optional.ofNullable(filters.getTo()).ifPresent(value -> queryParameterMap.put(TO, value));
     Optional.ofNullable(filters.getInstitutionId()).ifPresent(value -> queryParameterMap.put(INSTITUTION_ID, value));
@@ -99,7 +99,7 @@ public class QueryUtils {
   public static Map<String, Object> createMapForInstitutionOnboardingsQueryParameter(String taxCode, String subunitCode, String origin, String originId, OnboardingStatus status, String productId) {
     Map<String, Object> queryParameterMap = new HashMap<>();
     getOptionalForNullableAndEmpty(taxCode).ifPresent(value -> queryParameterMap.put(INSTITUTION_TAX_CODE, value));
-    queryParameterMap.put(INSTITUTION_SUBUNIT_CODE, subunitCode);
+    getOptionalForNullableAndEmpty(subunitCode).ifPresent(value -> queryParameterMap.put(INSTITUTION_SUBUNIT_CODE, subunitCode));
     getOptionalForNullableAndEmpty(origin).ifPresent(value -> queryParameterMap.put(INSTITUTION_ORIGIN, value));
     getOptionalForNullableAndEmpty(originId).ifPresent(value -> queryParameterMap.put(INSTITUTION_ORIGIN_ID, value));
     Optional.ofNullable(status).ifPresent(value -> queryParameterMap.put(STATUS, value.name()));

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -515,7 +515,7 @@ class OnboardingControllerTest {
                 .subunitCode("subunitCode")
                 .from("2023-12-01")
                 .to("2023-12-31")
-                .status("ACTIVE")
+                .status(OnboardingStatus.COMPLETED)
                 .build();
         when(onboardingService.onboardingGet(filters))
                 .thenReturn(Uni.createFrom().item(response));

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2278,7 +2278,7 @@ class OnboardingServiceDefaultTest {
                 .taxCode("taxCode")
                 .from("2023-12-01")
                 .to("2023-12-31")
-                .status("ACTIVE")
+                .status(OnboardingStatus.COMPLETED)
                 .page(page)
                 .size(size)
                 .build();
@@ -2302,7 +2302,7 @@ class OnboardingServiceDefaultTest {
                 .subunitCode("subunitCode")
                 .from("2023-12-01")
                 .to("2023-12-31")
-                .status("ACTIVE")
+                .status(OnboardingStatus.COMPLETED)
                 .page(page)
                 .size(size)
                 .build();
@@ -2331,7 +2331,7 @@ class OnboardingServiceDefaultTest {
                 .from("2023-12-01")
                 .to("2023-12-31")
                 .productIds(List.of("prod-io"))
-                .status("ACTIVE")
+                .status(OnboardingStatus.COMPLETED)
                 .skipPagination(true)
                 .build();
         UniAssertSubscriber<OnboardingGetResponse> subscriber = onboardingService
@@ -2362,7 +2362,7 @@ class OnboardingServiceDefaultTest {
                 .from("2023-12-01")
                 .to("2023-12-31")
                 .productIds(List.of("prod-io"))
-                .status("ACTIVE")
+                .status(OnboardingStatus.COMPLETED)
                 .skipPagination(true)
                 .build();
         UniAssertSubscriber<OnboardingGetResponse> subscriber = onboardingService
@@ -2374,7 +2374,7 @@ class OnboardingServiceDefaultTest {
         assertNotNull(response);
         assertNotNull(response.getItems());
         assertNotNull(response.getItems().get(0));
-        assertEquals(response.getItems().get(0).getPayment().getIban(), "iban");
+        assertEquals("iban", response.getItems().get(0).getPayment().getIban());
     }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

*   **onboarding-bff**:
    *   Added the `external-v2` tag to relevant OpenAPI endpoints for onboarding-related operations.
    *   Updated the `status` query parameter to use an `$ref` to `OnboardingStatus` schema for better type safety.
    *   Modified `OnboardingMsConnectorImpl` to correctly map string status values to the `OnboardingStatus` enum when querying onboardings.
*   **onboarding-ms**:
    *   Introduced the `external-v2` tag to various OpenAPI endpoints, including GET `/v1/onboarding`, PUT `/v1/onboarding/{onboardingId}/complete`, PUT `/v1/onboarding/{onboardingId}/reject`, and DELETE `/v1/onboarding/{onboardingId}`.
    *   Updated the `getOnboardingWithFilter` and `getOnboardingPending` endpoints to accept `OnboardingStatus` enum directly instead of a string, improving type safety.
    *   Modified `QueryUtils` to correctly map `OnboardingStatus` enum to its string representation for database queries.

#### Motivation and Context

the change refactors the `onboarding-ms` service to handle onboarding statuses using an enum (`OnboardingStatus`) instead of raw strings, enhancing type safety and maintainability. 

#### How Has This Been Tested?

*   **Unit Tests**: Existing unit tests in `onboarding-bff`, `onboarding-functions`, and `onboarding-ms` have been updated to pass with the new enum-based status handling and list-based document retrieval.

#### Screenshots (if appropriate):

N/A

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.