### PR TITLE
feat(auth): add SocketException as retryable exception [SELC-8622]

### DIFF
--- a/apps/auth/src/main/java/it/pagopa/selfcare/auth/util/GeneralUtils.java
+++ b/apps/auth/src/main/java/it/pagopa/selfcare/auth/util/GeneralUtils.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.auth.exception.InternalException;
 import it.pagopa.selfcare.auth.exception.InvalidRequestException;
 import it.pagopa.selfcare.auth.exception.ResourceNotFoundException;
 import jakarta.ws.rs.WebApplicationException;
+import java.net.SocketException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +52,7 @@ public class GeneralUtils {
 
   public static boolean checkIfIsRetryableException(Throwable throwable) {
     return throwable instanceof TimeoutException
+        || throwable instanceof SocketException
         || (throwable instanceof WebApplicationException webApplicationException
             && webApplicationException.getResponse().getStatus() == 429);
   }


### PR DESCRIPTION
#### List of Changes

- Added `SocketException` as a retryable exception in `GeneralUtils.checkIfIsRetryableException`

#### Motivation and Context

`SocketException` can occur due to transient network issues. Including it as a retryable exception ensures that operations failing due to socket-level errors are retried, improving resilience of the auth service.

#### How Has This Been Tested?

- Existing unit tests cover the `checkIfIsRetryableException` method; the new condition is covered by the existing test suite structure.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.