### PR TITLE
feat(document-ms): set OpenTelemetry log level to ERROR

### DIFF
--- a/apps/document-ms/src/main/resources/application.properties
+++ b/apps/document-ms/src/main/resources/application.properties
@@ -32,6 +32,7 @@ quarkus.rest-client.logging.scope=request-response
 quarkus.rest-client.logging.body-limit=50
 
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=INFO
+quarkus.log.category."io.opentelemetry.javaagent.instrumentation.azurecore".level=ERROR
 
 quarkus.smallrye-openapi.store-schema-directory=src/main/docs
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->


#### Problem

At every r/w operation on Azure Blob Storage, the OpenTelemetry Java agent emits the following warning:
`WARN [io.opentelemetry.javaagent.instrumentation.azurecore.v1_19.shaded.com.azure.core.tracing.opentelemetry.OpenTelemetryTracer] (executor-thread-1) Could not populate attribute with key '{}', type is not supported.`

The warning is generated by the shaded OpenTelemetry tracer when it encounters an unsupported attribute type while decorating Azure SDK spans. It does not affect functionality — the Blob Storage operation completes successfully regardless.

#### Solution

Set log level to `ERROR` on the `azurecore` package rather than the specific class, to avoid coupling the configuration to the internal shaded class name (`v1_19`), which may change across agent versions.
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.