### PR TITLE
fix: Improve error handling for onboarding retrieval

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
@@ -339,8 +339,8 @@ public class OnboardingServiceDefault implements OnboardingService {
         return Onboarding.findByIdOptional(onboardingId)
                 .onItem().transformToUni(opt ->
                         opt.map(Onboarding.class::cast)
-                                .map(o -> Uni.createFrom().item(o))
-                                .orElse(Uni.createFrom().failure(
+                                .map(Uni.createFrom()::item)
+                                .orElseGet(() -> Uni.createFrom().failure(
                                         new ResourceNotFoundException(
                                                 String.format("Onboarding with id %s not found!", onboardingId)))))
                 .flatMap(onboarding ->


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

This change refactors the error handling within the `OnboardingServiceDefault` class when retrieving onboarding information. Specifically, the `findByIdOptional` method's handling of a missing onboarding record has been updated. Previously, it used `.orElse(Uni.createFrom().failure(...))`, which would eagerly create a failure instance. This has been changed to `.orElseGet(() -> Uni.createFrom().failure(...))`, which creates the failure instance only when an onboarding record is not found. 

#### Motivation and Context

The previous implementation of error handling for retrieving onboarding records was creating a `ResourceNotFoundException`  even when the onboarding record was found. 

#### How Has This Been Tested?

The change was tested by:
1.  **Unit Testing:** The modified method's behavior was verified using unit tests to ensure that:
    *   When an onboarding record exists, the method successfully returns the onboarding object.
    *   When an onboarding record does not exist, the method correctly returns a `ResourceNotFoundException` via a `Uni.createFrom().failure()`.
    *   The exception is only created when the record is absent.
2.  **Integration Testing:** The `onboarding-ms` service was run and tested to confirm that existing API endpoints that rely on onboarding retrieval function as expected, and that the error handling for non-existent onboarding records is now more robust and efficient.

#### Screenshots (if appropriate):

N/A

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.