### PR TITLE
[SELC-8679] feat: add isTest in createInstitution request

### DIFF
--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -3401,6 +3401,9 @@
           },
           "legalForm" : {
             "type" : "string"
+          },
+          "isTest" : {
+            "type" : "boolean"
           }
         }
       },

--- a/apps/institution-ms/app/src/test/resources/features/institution.feature
+++ b/apps/institution-ms/app/src/test/resources/features/institution.feature
@@ -1040,14 +1040,15 @@ Feature: Institution
     And The response body contains field "id"
 
   @RemoveInstitutionIdAfterScenario
-  Scenario: Successfully create and update raw institution with legalForm
+  Scenario: Successfully create and update raw institution with legalForm and isTest
     # CREATE
     Given User login with username "j.doe" and password "test"
     And The following request body:
       """
       {
         "taxCode": "98765432100",
-        "legalForm": "legal"
+        "legalForm": "legal",
+        "isTest": true
       }
       """
     When I send a POST request to "/institutions"
@@ -1057,6 +1058,7 @@ Feature: Institution
       | origin    | SELC             |
       | originId  | SELC_98765432100 |
       | legalForm | legal            |
+      | isTest    | true             |
     And The response body contains field "id"
     And The response body doesn't contain field "supportEmail"
     # UPDATE
@@ -1077,6 +1079,7 @@ Feature: Institution
       | originId     | SELC_98765432100 |
       | supportEmail | test@pec.it      |
       | legalForm    | legal2           |
+      | isTest       | true             |
     And The response body contains field "id"
 
 # POST /institutions/insert/{externalId} (deprecated)

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
@@ -40,5 +40,6 @@ public class InstitutionRequest {
     private boolean delegation;
     private String istatCode;
     private String legalForm;
+    private Boolean isTest;
 
 }

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -523,8 +523,10 @@ class InstitutionControllerTest {
     void shouldCreateInstitution() throws Exception {
 
         InstitutionRequest institution = TestUtils.createSimpleInstitutionRequest();
+        institution.setIsTest(Boolean.TRUE);
         Institution response = TestUtils.createSimpleInstitutionPA();
         response.setLegalForm("legalForm");
+        response.setIsTest(Boolean.TRUE);
 
         when(institutionService.createInstitution(any())).thenReturn(response);
 
@@ -538,7 +540,8 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.legalForm").value("legalForm"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.legalForm").value("legalForm"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.isTest").value(Boolean.TRUE));
     }
 
     /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add isTest in createInstitution request
- align unit tests
- align cucumber tests

<!--- Describe your changes in detail -->

#### Motivation and Context
Added the isTest field to the createInstitution API request to support the creation and identification of test institutions.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
locally and by cucumber tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.