### PR TITLE
Align registry proxy Dapr app IDs

### DIFF
--- a/infra/resources/registry-proxy/dev-ar/registry-proxy.tf
+++ b/infra/resources/registry-proxy/dev-ar/registry-proxy.tf
@@ -127,7 +127,7 @@ locals {
 
   dapr_sidecar_settings = [
     {
-      app_id       = "party-reg-proxy"
+      app_id       = "selc-${module.local.config.env_short}-party-reg-proxy-ca"
       app_port     = 8080
       app_protocol = "http"
     }

--- a/infra/resources/registry-proxy/prod-ar/registry-proxy.tf
+++ b/infra/resources/registry-proxy/prod-ar/registry-proxy.tf
@@ -129,7 +129,7 @@ locals {
 
   dapr_sidecar_settings = [
     {
-      app_id       = "party-reg-proxy"
+      app_id       = "selc-${module.local.config.env_short}-party-reg-proxy-ca"
       app_port     = 8080
       app_protocol = "http"
     }

--- a/infra/resources/registry-proxy/uat-ar/registry-proxy.tf
+++ b/infra/resources/registry-proxy/uat-ar/registry-proxy.tf
@@ -400,7 +400,7 @@ module "container_app_registry_proxy_ms" {
   probes                         = local.probes
   tags                           = module.local.config.tags
   dapr_settings = [{
-    app_id       = "party-reg-proxy"
+    app_id       = "selc-${module.local.config.env_short}-party-reg-proxy-ca"
     app_port     = "8080"
     app_protocol = "http"
   }]


### PR DESCRIPTION
#### List of Changes

- Replace the hardcoded `party-reg-proxy` Dapr app ID with `selc-${module.local.config.env_short}-party-reg-proxy-ca` in the registry-proxy Terraform configuration.
- Apply the same naming rule in `dev-ar`, `uat-ar`, and `prod-ar` so every environment resolves the expected Container App identity.
- Keep the Dapr settings aligned between the sidecar configuration and the UAT container app module input.

#### Motivation and Context

The registry-proxy Terraform configuration still used a static Dapr app ID, while the deployed Container App follows an environment-qualified name. That mismatch makes the Dapr identity inconsistent with the actual target application. This change removes the hardcoded value and derives the app ID from the environment naming convention already used by the deployment.

#### How Has This Been Tested?

- Ran the local pre-commit hooks during `git commit`.
- `terraform fmt` passed on the modified files.
- `terraform docs` passed.
- `terraform validate` passed after running `terraform init -backend=false` in `infra/resources/registry-proxy/prod-ar`.

#### Screenshots (if appropriate):

- Not applicable.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
