### PR TITLE
Align infra PR workflows with DX plan

### DIFF
--- a/.github/workflows/pr_auth_infra.yml
+++ b/.github/workflows/pr_auth_infra.yml
@@ -19,43 +19,52 @@ on:
       - reopened
       - ready_for_review
     paths:
-      - 'infra/resources/**/auth.tf'
+      - 'infra/resources/auth/**'
       - '.github/workflows/pr_auth_infra.yml'
       - '.github/workflows/call_code_review_infra.yml'
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Auth Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/auth/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/auth
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Auth Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/auth/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/auth
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Auth Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/auth/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/auth
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_dashboard_bff_infra.yml
+++ b/.github/workflows/pr_dashboard_bff_infra.yml
@@ -25,73 +25,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Dashboard BFF Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/dashboard-bff/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-PNPG] Dashboard BFF Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/dashboard-bff/dev-pnpg
-      tf_environment: dev-pnpg
+      environment: dev-pnpg
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Dashboard BFF Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/dashboard-bff/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-PNPG] Dashboard BFF Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/dashboard-bff/uat-pnpg
-      tf_environment: uat-pnpg
+      environment: uat-pnpg
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Dashboard BFF Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/dashboard-bff/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-PNPG] Dashboard BFF Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/dashboard-bff/prod-pnpg
-      tf_environment: prod-pnpg
+      environment: prod-pnpg
+      base_path: infra/resources/dashboard-bff
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_delegation_cdc_infra.yml
+++ b/.github/workflows/pr_delegation_cdc_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Delegation cdc Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/delegation-cdc/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/delegation-cdc
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Delegation cdc Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/delegation-cdc/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/delegation-cdc
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Delegation cdc Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/delegation-cdc/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/delegation-cdc
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_document_ms_infra.yml
+++ b/.github/workflows/pr_document_ms_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] Document MS Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/document-ms/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/document-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] Document MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/document-ms/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/document-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] Document MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/document-ms/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/document-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_external_api_infra.yml
+++ b/.github/workflows/pr_external_api_infra.yml
@@ -28,73 +28,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] External API Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/external-api/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/external-api
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_ar_api:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] API Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/api/dev-ar
-      tf_environment: api-dev-ar
+      environment: api-dev-ar
+      base_path: infra/resources/api
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] External API Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/external-api/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/external-api
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_ar_api:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] API Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/api/uat-ar
-      tf_environment: api-uat-ar
+      environment: api-uat-ar
+      base_path: infra/resources/api
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] External API Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/external-api/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/external-api
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_ar_api:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] API Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/api/prod-ar
-      tf_environment: api-prod-ar
+      environment: api-prod-ar
+      base_path: infra/resources/api
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_iam_infra.yml
+++ b/.github/workflows/pr_iam_infra.yml
@@ -19,43 +19,52 @@ on:
       - reopened
       - ready_for_review
     paths:
-      - 'infra/resources/**/iam.tf'
+      - 'infra/resources/iam/**'
       - '.github/workflows/pr_iam_infra.yml'
       - '.github/workflows/call_code_review_infra.yml'
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] IAM Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/iam/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/iam
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] IAM Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/iam/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/iam
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] IAM Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/iam/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/iam
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_institution_ms_infra.yml
+++ b/.github/workflows/pr_institution_ms_infra.yml
@@ -25,73 +25,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Institution Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/institution-ms/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/institution-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-PNPG] Institution Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/institution-ms/dev-pnpg
-      tf_environment: dev-pnpg
+      environment: dev-pnpg
+      base_path: infra/resources/institution-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Institution Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/institution-ms/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/institution-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-PNPG] Institution Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/institution-ms/uat-pnpg
-      tf_environment: uat-pnpg
+      environment: uat-pnpg
+      base_path: infra/resources/institution-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Institution Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/institution-ms/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/institution-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-PNPG] Institution Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/institution-ms/prod-pnpg
-      tf_environment: prod-pnpg
+      environment: prod-pnpg
+      base_path: infra/resources/institution-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_institution_send_mail_scheduler_infra.yml
+++ b/.github/workflows/pr_institution_send_mail_scheduler_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Institution SendMailScheduler Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/institution-send-mail-scheduler/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/institution-send-mail-scheduler
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Institution SendMailScheduler Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/institution-send-mail-scheduler/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/institution-send-mail-scheduler
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Institution SendMailScheduler Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/institution-send-mail-scheduler/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/institution-send-mail-scheduler
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_product_cdc_infra.yml
+++ b/.github/workflows/pr_product_cdc_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] Product CDC Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/product-cdc/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/product-cdc
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] Product CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/product-cdc/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/product-cdc
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] Product CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/product-cdc/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/product-cdc
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_product_infra.yml
+++ b/.github/workflows/pr_product_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] Product Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/product/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/product
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] Product Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/product/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/product
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] Product Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/product/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/product
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_registry_proxy_infra.yml
+++ b/.github/workflows/pr_registry_proxy_infra.yml
@@ -37,16 +37,6 @@ jobs:
       use_private_agent: true
       use_labels: true
       override_labels: dev
-    # uses: ./.github/workflows/call_code_review_infra.yml
-    # name: '[DEV-AR] Registry Proxy Infra Code Review'
-    # if: ${{ !startsWith(github.ref_name, 'releases/') }}
-    # secrets: inherit
-    # with:
-    #   environment: dev
-    #   dir: ./infra/resources/registry-proxy/dev-ar
-    #   tf_environment: dev-ar
-    #   env_vars: |
-    #     TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
 
   code_review_uat_ar:
     uses: pagopa/dx/.github/workflows/infra_plan.yaml@main

--- a/.github/workflows/pr_registry_proxy_runner_infra.yml
+++ b/.github/workflows/pr_registry_proxy_runner_infra.yml
@@ -25,37 +25,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-AR] Registry Proxy Runner Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/registry-proxy-runner/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/registry-proxy-runner
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-AR] Registry Proxy Runner Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/registry-proxy-runner/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/registry-proxy-runner
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-AR] Registry Proxy Runner Infra Code Review'
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/registry-proxy-runner/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/registry-proxy-runner
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_user_cdc_infra.yml
+++ b/.github/workflows/pr_user_cdc_infra.yml
@@ -2,6 +2,7 @@ name: Code Review - User CDC Infra
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: read
 
@@ -25,73 +26,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] User CDC Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-cdc/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/user-cdc
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-PNPG] User CDC Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-cdc/dev-pnpg
-      tf_environment: dev-pnpg
+      environment: dev-pnpg
+      base_path: infra/resources/user-cdc
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] User CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-cdc/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/user-cdc
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-PNPG] User CDC Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-cdc/uat-pnpg
-      tf_environment: uat-pnpg
+      environment: uat-pnpg
+      base_path: infra/resources/user-cdc
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] User CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-cdc/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/user-cdc
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-PNPG] User CDC Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-cdc/prod-pnpg
-      tf_environment: prod-pnpg
+      environment: prod-pnpg
+      base_path: infra/resources/user-cdc
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_user_group_cdc_infra.yml
+++ b/.github/workflows/pr_user_group_cdc_infra.yml
@@ -2,6 +2,7 @@ name: Code Review - User Group CDC Infra
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: read
 
@@ -25,37 +26,46 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] User Group CDC Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-group-cdc/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/user-group-cdc
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] User Group CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-group-cdc/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/user-group-cdc
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] User Group CDC Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-group-cdc/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/user-group-cdc
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_user_group_ms_infra.yml
+++ b/.github/workflows/pr_user_group_ms_infra.yml
@@ -2,6 +2,7 @@ name: Code Review - User Group MS Infra
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: read
 
@@ -25,73 +26,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] User Group MS Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-group-ms/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/user-group-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-PNPG] User Group MS Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-group-ms/dev-pnpg
-      tf_environment: dev-pnpg
+      environment: dev-pnpg
+      base_path: infra/resources/user-group-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] User Group MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-group-ms/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/user-group-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-PNPG] User Group MS Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-group-ms/uat-pnpg
-      tf_environment: uat-pnpg
+      environment: uat-pnpg
+      base_path: infra/resources/user-group-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] User Group MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-group-ms/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/user-group-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-PNPG] User Group MS Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-group-ms/prod-pnpg
-      tf_environment: prod-pnpg
+      environment: prod-pnpg
+      base_path: infra/resources/user-group-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod

--- a/.github/workflows/pr_user_ms_infra.yml
+++ b/.github/workflows/pr_user_ms_infra.yml
@@ -2,6 +2,7 @@ name: Code Review - User MS Infra
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: read
 
@@ -25,73 +26,91 @@ on:
 
 jobs:
   code_review_dev_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[DEV-AR] User MS Infra Code Review"
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-ms/dev-ar
-      tf_environment: dev-ar
+      environment: dev-ar
+      base_path: infra/resources/user-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_dev_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[DEV-PNPG] User MS Infra Code Review'
     if: ${{ !startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: dev
-      dir: ./infra/resources/user-ms/dev-pnpg
-      tf_environment: dev-pnpg
+      environment: dev-pnpg
+      base_path: infra/resources/user-ms
+      override_github_environment: dev
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: dev
 
   code_review_uat_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[UAT-AR] User MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-ms/uat-ar
-      tf_environment: uat-ar
+      environment: uat-ar
+      base_path: infra/resources/user-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_uat_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[UAT-PNPG] User MS Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: uat
-      dir: ./infra/resources/user-ms/uat-pnpg
-      tf_environment: uat-pnpg
+      environment: uat-pnpg
+      base_path: infra/resources/user-ms
+      override_github_environment: uat
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: uat
 
   code_review_prod_ar:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: "[PROD-AR] User MS Infra Code Review"
     if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-ms/prod-ar
-      tf_environment: prod-ar
+      environment: prod-ar
+      base_path: infra/resources/user-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod
 
   code_review_prod_pnpg:
-    uses: ./.github/workflows/call_code_review_infra.yml
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: '[PROD-PNPG] User MS Infra Code Review'
-    if: ${{ !startsWith(github.ref_name, 'releases/') }}
+    if: ${{ startsWith(github.ref_name, 'releases/') }}
     secrets: inherit
     with:
-      environment: prod
-      dir: ./infra/resources/user-ms/prod-pnpg
-      tf_environment: prod-pnpg
+      environment: prod-pnpg
+      base_path: infra/resources/user-ms
+      override_github_environment: prod
       env_vars: |
         TF_VAR_image_tag=sha-$(git rev-parse --short ${{ github.sha }})
+      use_private_agent: true
+      use_labels: true
+      override_labels: prod


### PR DESCRIPTION
#### List of Changes

- migrate the remaining pr_*_infra.yml workflows to pagopa/dx/.github/workflows/infra_plan.yaml@main
- replace the legacy dir and tf_environment inputs with base_path, scoped environment, and DX label overrides
- align workflow path filters for the auth and IAM infra workflows with the actual resource folders
- fix inconsistent PNPG release conditions in institution and user-related infra workflows
- add id-token: write where required by the new reusable workflow

#### Motivation and Context

This change completes the migration of infra PR workflows to the DX reusable plan workflow so that all infrastructure reviews follow the same execution model and environment mapping.

It also removes inconsistencies left by the legacy setup, especially around PNPG release gating and overly narrow path filters, which could lead to missed or incorrect workflow runs.

#### How Has This Been Tested?

- validated all updated workflow files with VS Code diagnostics and confirmed that no YAML errors are reported
- reviewed the workflow diff against origin/main for the affected pr_*_infra.yml files
- GitHub Actions workflows were not executed from the local environment

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
