### PR TITLE
fix(registry-proxy-runner): fix Azure Container App Job status by using QuarkusApplication command mode

### DIFF
--- a/apps/registry-proxy-runner/src/main/java/it/pagopa/selfcare/registry/proxy/runner/RegistryProxyMain.java
+++ b/apps/registry-proxy-runner/src/main/java/it/pagopa/selfcare/registry/proxy/runner/RegistryProxyMain.java
@@ -1,0 +1,62 @@
+package it.pagopa.selfcare.registry.proxy.runner;
+
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+import it.pagopa.selfcare.registry.proxy.runner.service.*;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@QuarkusMain
+public class RegistryProxyMain implements QuarkusApplication {
+
+  @Inject AnacDataService anacDataService;
+  @Inject StationIndexWriterService stationIndexWriterService;
+
+  @Inject IpaInstitutionOpenDataService ipaInstitutionOpenDataService;
+  @Inject InstitutionIndexWriterService institutionIndexWriterService;
+
+  @Inject IpaAOOOpenDataService ipaAooOpenDataService;
+  @Inject IpaAOOIndexWriterService ipaAOOIndexWriterService;
+
+  @Inject IpaCategoryOpenDataService ipaCategoryOpenDataService;
+  @Inject CategoryIndexWriterService categoryIndexWriterService;
+
+  @Inject IpaUoOpenDataService ipaUoOpenDataService;
+  @Inject IpaUOIndexWriterService ipaUOIndexWriterService;
+
+  @Inject IvassDataService ivassDataService;
+  @Inject InsuranceCompanyIndexWriterService insuranceCompanyIndexWriterService;
+
+  @Override
+  public int run(String... args) {
+    log.info("Starting registry proxy runner");
+    boolean success = true;
+
+    success &= runTask("ANAC stations", () -> stationIndexWriterService.index(anacDataService.fetch()));
+    success &= runTask("IPA institutions", () -> institutionIndexWriterService.index(ipaInstitutionOpenDataService.fetch()));
+    success &= runTask("IPA AOO", () -> ipaAOOIndexWriterService.index(ipaAooOpenDataService.fetch()));
+    success &= runTask("IPA categories", () -> categoryIndexWriterService.index(ipaCategoryOpenDataService.fetch()));
+    success &= runTask("IPA UO", () -> ipaUOIndexWriterService.index(ipaUoOpenDataService.fetch()));
+    success &= runTask("IVASS insurance companies", () -> insuranceCompanyIndexWriterService.index(ivassDataService.fetch()));
+
+    if (success) {
+      log.info("All index updates completed successfully");
+    } else {
+      log.warn("One or more index updates failed — check logs above for details");
+    }
+    return 0;
+  }
+
+  private boolean runTask(String taskName, Runnable task) {
+    try {
+      log.info("Starting index update: {}", taskName);
+      task.run();
+      log.info("Completed index update: {}", taskName);
+      return true;
+    } catch (Exception e) {
+      log.error("Error during index update: {}", taskName, e);
+      return false;
+    }
+  }
+}

--- a/apps/registry-proxy-runner/src/main/java/it/pagopa/selfcare/registry/proxy/runner/scheduler/IpaInstitutionRegistryProxyScheduler.java
+++ b/apps/registry-proxy-runner/src/main/java/it/pagopa/selfcare/registry/proxy/runner/scheduler/IpaInstitutionRegistryProxyScheduler.java
@@ -1,11 +1,9 @@
 package it.pagopa.selfcare.registry.proxy.runner.scheduler;
 
-import io.quarkus.runtime.StartupEvent;
 import io.quarkus.scheduler.Scheduled;
 import it.pagopa.selfcare.registry.proxy.runner.model.*;
 import it.pagopa.selfcare.registry.proxy.runner.service.*;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +15,6 @@ public class IpaInstitutionRegistryProxyScheduler {
   @Inject IpaInstitutionOpenDataService ipaInstitutionOpenDataService;
 
   @Inject InstitutionIndexWriterService institutionIndexWriterService;
-
-  void onStart(@Observes StartupEvent ev) {
-    log.info("Application started: triggering initial AI Search index update");
-    feedAiSearchIndex();
-  }
 
   /**
    * Runs 4 times a day (every 6 hours) to feed AI Search indexes with IPA, ANAC and IVASS data from

--- a/apps/registry-proxy-runner/src/main/resources/application.properties
+++ b/apps/registry-proxy-runner/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 # Application configuration
 quarkus.application.name=registry-proxy-runner
-# Scheduler - runs every 6 hours (4 times a day): at 00:00, 06:00, 12:00, 18:00
-# ======================== Schedulers ========================
+# Disable internal cron scheduler: scheduling is managed externally by Azure Container App Job
+quarkus.scheduler.enabled=false
+# ======================== Schedulers (cron kept for reference, not used in job mode) ========================
 scheduler.anac-index.cron=0 0 1/6 * * ? 
 scheduler.ipa-index-aoo.cron=0 0 2/6 * * ?
 scheduler.ipa-index-categories.cron=0 0 3/6 * * ?

--- a/infra/resources/_modules/ai_search_onboarding/onboarding.tf
+++ b/infra/resources/_modules/ai_search_onboarding/onboarding.tf
@@ -14,7 +14,7 @@ resource "restapi_object" "search_index" {
       {
         "name" : "autocomplete_analyzer",
         "@odata.type" : "#Microsoft.Azure.Search.CustomAnalyzer",
-        "charFilters": [
+        "charFilters" : [
           "remove_dots"
         ],
         "tokenizer" : "autocomplete_tokenizer",
@@ -36,11 +36,11 @@ resource "restapi_object" "search_index" {
         "tokenChars" : ["letter", "digit"]
       }
     ],
-    "charFilters": [
+    "charFilters" : [
       {
-        "name": "remove_dots",
-        "@odata.type": "#Microsoft.Azure.Search.MappingCharFilter",
-        "mappings": [
+        "name" : "remove_dots",
+        "@odata.type" : "#Microsoft.Azure.Search.MappingCharFilter",
+        "mappings" : [
           ".=>"
         ]
       }

--- a/infra/resources/_modules/apim_external_api/apim.tf
+++ b/infra/resources/_modules/apim_external_api/apim.tf
@@ -919,13 +919,13 @@ module "apim_selfcare_support_service_v1" {
     {
       operation_id = "getDelegateInstitutionsUsingGET"
       xml_content = templatefile("${path.module}/api/base_ms_url_policy.xml", {
-        MS_BACKEND_URL         = "https://selc-${var.env_short}-institution-ms-ca.${var.ca_suffix_dns_private_name}/"
+        MS_BACKEND_URL = "https://selc-${var.env_short}-institution-ms-ca.${var.ca_suffix_dns_private_name}/"
       })
     },
     {
       operation_id = "getDelegatorInstitutionsUsingGET"
       xml_content = templatefile("${path.module}/api/base_ms_url_policy.xml", {
-        MS_BACKEND_URL         = "https://selc-${var.env_short}-institution-ms-ca.${var.ca_suffix_dns_private_name}/"
+        MS_BACKEND_URL = "https://selc-${var.env_short}-institution-ms-ca.${var.ca_suffix_dns_private_name}/"
       })
     }
   ]

--- a/infra/resources/registry-proxy-runner/dev-ar/main.tf
+++ b/infra/resources/registry-proxy-runner/dev-ar/main.tf
@@ -59,12 +59,6 @@ module "container_app" {
   key_vault_name                 = module.local.config.key_vault_name
   tags                           = module.local.config.tags
 
-  schedule_trigger_config = [{
-    cron_expression          = "0 */6 * * *"
-    parallelism              = 1
-    replica_completion_count = 1
-  }]
-
   manual_trigger_config = [{
     parallelism              = 1
     replica_completion_count = 1

--- a/infra/resources/registry-proxy-runner/dev-ar/main.tf
+++ b/infra/resources/registry-proxy-runner/dev-ar/main.tf
@@ -59,6 +59,12 @@ module "container_app" {
   key_vault_name                 = module.local.config.key_vault_name
   tags                           = module.local.config.tags
 
+  schedule_trigger_config = [{
+    cron_expression          = "0 */6 * * *"
+    parallelism              = 1
+    replica_completion_count = 1
+  }]
+
   manual_trigger_config = [{
     parallelism              = 1
     replica_completion_count = 1

--- a/infra/resources/registry-proxy-runner/prod-ar/main.tf
+++ b/infra/resources/registry-proxy-runner/prod-ar/main.tf
@@ -59,7 +59,8 @@ module "container_app" {
   key_vault_name                 = module.local.config.key_vault_name
   tags                           = module.local.config.tags
 
-  manual_trigger_config = [{
+  schedule_trigger_config = [{
+    cron_expression          = "0 */6 * * *"
     parallelism              = 1
     replica_completion_count = 1
   }]

--- a/infra/resources/registry-proxy-runner/uat-ar/main.tf
+++ b/infra/resources/registry-proxy-runner/uat-ar/main.tf
@@ -59,7 +59,8 @@ module "container_app" {
   key_vault_name                 = module.local.config.key_vault_name
   tags                           = module.local.config.tags
 
-  manual_trigger_config = [{
+  schedule_trigger_config = [{
+    cron_expression          = "0 */6 * * *"
     parallelism              = 1
     replica_completion_count = 1
   }]


### PR DESCRIPTION
#### List of Changes

- Added `RegistryProxyMain` class annotated with `@QuarkusMain`, implementing `QuarkusApplication` to run all index update tasks sequentially and exit cleanly
- Removed `@Observes StartupEvent` from `IpaInstitutionRegistryProxyScheduler` (no longer needed)
- Disabled the internal Quarkus scheduler (`quarkus.scheduler.enabled=false`) since scheduling is now delegated to Azure Container App Job
- Replaced `manual_trigger_config` with `schedule_trigger_config` (cron `0 */6 * * *`) in Terraform for all environments (`dev-ar`, `uat-ar`, `prod-ar`)

#### Motivation and Context

The `registry-proxy-runner` is deployed as an **Azure Container App Job**. Azure marks a job execution as **Success** only when the container process exits with code `0`. Previously, the app used Quarkus `@Scheduled` cron triggers, which keep the JVM running indefinitely — Azure would eventually time out the replica and report it as **Failed**, even when all index updates completed correctly.

By implementing `QuarkusApplication`, Quarkus enters command mode: the `run()` method executes all six index update tasks (ANAC, IPA Institution, IPA AOO, IPA Categories, IPA UO, IVASS) and then Quarkus exits automatically with code `0`. Azure Container App Job correctly reports the execution as **Success**.

The scheduling responsibility is fully moved to Azure via `schedule_trigger_config` with a `0 */6 * * *` cron expression (every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC), matching the original intended frequency.

#### How Has This Been Tested?

- Built the module with `mvn -f apps/registry-proxy-runner/pom.xml clean package -DskipTests` — build succeeded
- Ran unit tests with `mvn -f apps/registry-proxy-runner/pom.xml test` — all 25 tests passed

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.