### PR TITLE
[SELC-8756] feat: Save userUid for approve and reject operation

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -35,6 +35,7 @@ public class Onboarding {
     private LocalDateTime activatedAt;
     private LocalDateTime deletedAt;
     private String reasonForReject;
+    private String processedByUserUid;
     private Boolean isAggregator;
     private Aggregator aggregator;
     private String delegationId;

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -1336,6 +1336,15 @@
             "type" : "string"
           }
         } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ApproveRequest"
+              }
+            }
+          }
+        },
         "responses" : {
           "200" : {
             "description" : "OK",
@@ -1969,6 +1978,14 @@
             "type" : "string"
           },
           "role" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ApproveRequest" : {
+        "type" : "object",
+        "properties" : {
+          "userUid" : {
             "type" : "string"
           }
         }
@@ -3044,6 +3061,9 @@
         "type" : "object",
         "properties" : {
           "reasonForReject" : {
+            "type" : "string"
+          },
+          "userUid" : {
             "type" : "string"
           }
         }

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -974,6 +974,11 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApproveRequest"
       responses:
         "200":
           description: OK
@@ -1446,6 +1451,11 @@ components:
         email:
           type: string
         role:
+          type: string
+    ApproveRequest:
+      type: object
+      properties:
+        userUid:
           type: string
     BillingPaRequest:
       type: object
@@ -2248,6 +2258,8 @@ components:
       type: object
       properties:
         reasonForReject:
+          type: string
+        userUid:
           type: string
     RecipientCodeStatus:
       enum:

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -386,9 +386,9 @@ public class OnboardingController {
     )
     @PUT
     @Path("/{onboardingId}/approve")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Uni<Response> approve(@PathParam(value = "onboardingId") String onboardingId) {
-        return onboardingService.approve(onboardingId)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Uni<Response> approve(@PathParam(value = "onboardingId") String onboardingId, ApproveRequest approveRequest) {
+        return onboardingService.approve(onboardingId, approveRequest)
                 .map(ignore -> Response
                         .status(HttpStatus.SC_OK)
                         .build());
@@ -443,8 +443,7 @@ public class OnboardingController {
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{onboardingId}/reject")
     public Uni<Response> delete(@PathParam(value = "onboardingId") String onboardingId, @Valid ReasonRequest reason) {
-        String reasonForReject = reason.getReasonForReject();
-        return onboardingService.rejectOnboarding(onboardingId, reasonForReject)
+        return onboardingService.rejectOnboarding(onboardingId, reason)
                 .map(ignore -> Response
                         .status(HttpStatus.SC_NO_CONTENT)
                         .build());

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/ApproveRequest.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/ApproveRequest.java
@@ -3,7 +3,7 @@ package it.pagopa.selfcare.onboarding.controller.request;
 import lombok.Data;
 
 @Data
-public class ReasonRequest {
-    private String reasonForReject;
+public class ApproveRequest {
     private String userUid;
 }
+

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -39,6 +39,7 @@ public class Onboarding extends ReactivePanacheMongoEntityBase {
     private OnboardingStatus status;
     private AdditionalInformations additionalInformations;
     private String reasonForReject;
+    private String processedByUserUid;
     private Boolean isAggregator;
     private Boolean toAddOnAggregates;
     private Payment payment;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -53,7 +53,7 @@ public interface OnboardingService {
 
     Uni<OnboardingResponse> onboardingUserPg(Onboarding onboarding, List<UserRequest> userRequests);
 
-    Uni<OnboardingGet> approve(String onboardingId);
+    Uni<OnboardingGet> approve(String onboardingId, ApproveRequest approveRequest);
 
     Uni<Onboarding> complete(String tokenId, FormItem formItem);
 
@@ -65,7 +65,7 @@ public interface OnboardingService {
 
     Uni<OnboardingGetResponse> onboardingGet(OnboardingGetFilters filters);
 
-    Uni<Long> rejectOnboarding(String onboardingId, String reasonForReject);
+    Uni<Long> rejectOnboarding(String onboardingId, ReasonRequest reasonRequest);
 
     Uni<Long> deleteOnboarding(String onboardingId);
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/helper/OnboardingQueryHelper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/helper/OnboardingQueryHelper.java
@@ -7,8 +7,10 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.tuples.Tuple2;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.controller.request.ApproveRequest;
 import it.pagopa.selfcare.onboarding.controller.request.CheckManagerRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingUserRequest;
+import it.pagopa.selfcare.onboarding.controller.request.ReasonRequest;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
@@ -125,9 +127,15 @@ public class OnboardingQueryHelper {
     // Aggiornamenti stato onboarding
     // -------------------------------------------------------------------------
 
-    public static Uni<Long> updateReasonForRejectAndUpdateStatus(String onboardingId, String reasonForReject) {
+    public static Uni<Long> updateReasonForRejectAndUpdateStatus(String onboardingId, ReasonRequest reasonForReject) {
         Map<String, Object> params = QueryUtils.createMapForOnboardingReject(
                 reasonForReject, OnboardingStatus.REJECTED.name());
+        Document query = QueryUtils.buildUpdateDocument(params);
+        return performUpdate(onboardingId, query);
+    }
+
+    public static Uni<Long> updateApproverUserUuid(String onboardingId, ApproveRequest approveRequest) {
+        Map<String, Object> params = QueryUtils.createMapForOnboardingApprove(approveRequest);
         Document query = QueryUtils.buildUpdateDocument(params);
         return performUpdate(onboardingId, query);
     }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
@@ -208,7 +208,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     // -------------------------------------------------------------------------
 
     @Override
-    public Uni<OnboardingGet> approve(String onboardingId) {
+    public Uni<OnboardingGet> approve(String onboardingId, ApproveRequest approveRequest) {
         return queryHelper.retrieveOnboardingAndCheckIfExpired(onboardingId)
                 .onItem().transformToUni(queryHelper::checkIfToBeValidated)
                 .onItem().transformToUni(onboarding ->
@@ -217,9 +217,11 @@ public class OnboardingServiceDefault implements OnboardingService {
                                         validationHelper.verifyAlreadyOnboardingForProductAndProductParent(
                                                 onboarding.getInstitution(), product.getId(), product.getParentId()))
                                 .replaceWith(onboarding))
-                .onItem().transformToUni(onboarding ->
+            .onItem().call(onboarding ->
+                    OnboardingQueryHelper.updateApproverUserUuid(onboardingId, approveRequest))
+            .onItem().transformToUni(onboarding ->
                         onboardingOrchestrationEnabled
-                                ? orchestrationService.triggerOrchestration(onboarding.getId(), null).map(ignore -> onboarding)
+                                ? orchestrationService.triggerOrchestration(onboardingId, null).map(ignore -> onboarding)
                                 : Uni.createFrom().item(onboarding))
                 .flatMap(onboardingResponseFactory::toGetResponse);
     }
@@ -260,7 +262,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     @Override
-    public Uni<Long> rejectOnboarding(String onboardingId, String reasonForReject) {
+    public Uni<Long> rejectOnboarding(String onboardingId, ReasonRequest reason) {
         return Onboarding.findById(onboardingId)
                 .onItem().transform(Onboarding.class::cast)
                 .onItem().transformToUni(o ->
@@ -269,7 +271,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                                         String.format("Onboarding with id %s is COMPLETED!", onboardingId)))
                                 : Uni.createFrom().item(o))
                 .onItem().transformToUni(id ->
-                        OnboardingQueryHelper.updateReasonForRejectAndUpdateStatus(onboardingId, reasonForReject))
+                        OnboardingQueryHelper.updateReasonForRejectAndUpdateStatus(onboardingId, reason))
                 .onItem().transformToUni(onboarding ->
                         onboardingOrchestrationEnabled
                                 ? orchestrationService.triggerOrchestration(onboardingId, "60").map(ignore -> onboarding)

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -7,6 +7,8 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Sorts;
 import com.mongodb.client.model.Updates;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.controller.request.ApproveRequest;
+import it.pagopa.selfcare.onboarding.controller.request.ReasonRequest;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.model.OnboardingGetFilters;
 import java.time.LocalDate;
@@ -116,11 +118,18 @@ public class QueryUtils {
     return Optional.ofNullable(value).filter(v -> !v.isBlank());
   }
 
-  public static Map<String, Object> createMapForOnboardingReject(String reasonForReject, String onboardingStatus) {
+  public static Map<String, Object> createMapForOnboardingReject(ReasonRequest reasonForReject, String onboardingStatus) {
     Map<String, Object> queryParameterMap = new HashMap<>();
-    Optional.ofNullable(reasonForReject).ifPresent(value -> queryParameterMap.put("reasonForReject", value));
+    Optional.ofNullable(reasonForReject.getReasonForReject()).ifPresent(value -> queryParameterMap.put("reasonForReject", value));
+    Optional.ofNullable(reasonForReject.getUserUid()).ifPresent(value -> queryParameterMap.put("processedByUserUid", value));
     Optional.ofNullable(onboardingStatus).ifPresent(value -> queryParameterMap.put(STATUS, value));
     queryParameterMap.put("updatedAt", LocalDateTime.now());
+    return queryParameterMap;
+  }
+
+  public static Map<String, Object> createMapForOnboardingApprove(ApproveRequest approveRequest) {
+    Map<String, Object> queryParameterMap = new HashMap<>();
+    Optional.ofNullable(approveRequest.getUserUid()).ifPresent(value -> queryParameterMap.put("processedByUserUid", value));
     return queryParameterMap;
   }
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -461,8 +461,9 @@ class OnboardingControllerTest {
         String onboardingId = "actual-onboarding-id";
         ReasonRequest reasonRequest = new ReasonRequest();
         reasonRequest.setReasonForReject("string");
+        reasonRequest.setUserUid("uuid");
 
-        when(onboardingService.rejectOnboarding(onboardingId, "string"))
+        when(onboardingService.rejectOnboarding(onboardingId, reasonRequest))
                 .thenReturn(Uni.createFrom().item(1L));
 
         given()
@@ -476,7 +477,7 @@ class OnboardingControllerTest {
 
         ArgumentCaptor<String> expectedId = ArgumentCaptor.forClass(String.class);
         verify(onboardingService, times(1))
-                .rejectOnboarding(expectedId.capture(), eq("string"));
+                .rejectOnboarding(expectedId.capture(), eq(reasonRequest));
         assertEquals(expectedId.getValue(), onboardingId);
     }
 
@@ -486,8 +487,9 @@ class OnboardingControllerTest {
         String onboardingId = "actual-onboarding-id";
         ReasonRequest reasonRequest = new ReasonRequest();
         reasonRequest.setReasonForReject("string");
+        reasonRequest.setUserUid("uuid");
 
-        when(onboardingService.rejectOnboarding(onboardingId, "string"))
+        when(onboardingService.rejectOnboarding(onboardingId, reasonRequest))
                 .thenThrow(InvalidRequestException.class);
 
         given()
@@ -501,7 +503,7 @@ class OnboardingControllerTest {
 
         ArgumentCaptor<String> expectedId = ArgumentCaptor.forClass(String.class);
         verify(onboardingService, times(1))
-                .rejectOnboarding(expectedId.capture(), eq("string"));
+                .rejectOnboarding(expectedId.capture(), eq(reasonRequest));
         assertEquals(expectedId.getValue(), onboardingId);
     }
 
@@ -588,17 +590,22 @@ class OnboardingControllerTest {
     @TestSecurity(user = "userJwt")
     void approve() {
         OnboardingGet onboardingGet = dummyOnboardingGet();
-        when(onboardingService.approve(onboardingGet.getId()))
+        ApproveRequest approveRequest = new ApproveRequest();
+        approveRequest.setUserUid("user-uid-test");
+
+        when(onboardingService.approve(onboardingGet.getId(), approveRequest))
                 .thenReturn(Uni.createFrom().item(onboardingGet));
 
         given()
                 .when()
+                .body(approveRequest)
+                .contentType(ContentType.JSON)
                 .put("/{onboardingId}/approve", onboardingGet.getId())
                 .then()
                 .statusCode(200);
 
         verify(onboardingService, times(1))
-                .approve(onboardingGet.getId());
+                .approve(onboardingGet.getId(), approveRequest);
     }
 
     @Test

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2456,12 +2456,15 @@ class OnboardingServiceDefaultTest {
     void testOnboardingUpdateStatusOK() {
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setUserUid("uuid");
+        reasonRequest.setReasonForReject("reason");
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
         mockUpdateOnboarding(onboarding.getId(), 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId(), "string")
+                .rejectOnboarding(onboarding.getId(), reasonRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -2473,12 +2476,15 @@ class OnboardingServiceDefaultTest {
         Onboarding onboarding = createDummyOnboarding();
         onboarding.setStatus(OnboardingStatus.COMPLETED);
         PanacheMock.mock(Onboarding.class);
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setUserUid("uuid");
+        reasonRequest.setReasonForReject("reason");
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
         mockUpdateOnboarding(onboarding.getId(), 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId(), "string")
+                .rejectOnboarding(onboarding.getId(), reasonRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -2489,12 +2495,15 @@ class OnboardingServiceDefaultTest {
     void testOnboardingDeleteOnboardingNotFoundOrAlreadyDeleted() {
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setUserUid("uuid");
+        reasonRequest.setReasonForReject("reason");
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
         mockUpdateOnboarding(onboarding.getId(), 0L);
 
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId(), "string")
+                .rejectOnboarding(onboarding.getId(), reasonRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -2604,6 +2613,8 @@ class OnboardingServiceDefaultTest {
     void approve() {
         Onboarding onboarding = createDummyOnboarding();
         onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
+        ApproveRequest approveRequest = new ApproveRequest();
+        approveRequest.setUserUid("useruid");
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findByIdOptional(any()))
                 .thenReturn(Uni.createFrom().item(Optional.of(onboarding)));
@@ -2620,7 +2631,7 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(true);
 
         UniAssertSubscriber<OnboardingGet> subscriber = onboardingService
-                .approve(onboarding.getId())
+                .approve(onboarding.getId(), approveRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -2633,6 +2644,8 @@ class OnboardingServiceDefaultTest {
     void approve_throwExceptionIfOnboardingIsNotToBeValidated() {
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
+        ApproveRequest approveRequest = new ApproveRequest();
+        approveRequest.setUserUid("useruid");
         when(Onboarding.findByIdOptional(any()))
                 .thenReturn(Uni.createFrom().item(Optional.of(onboarding)));
 
@@ -2640,7 +2653,7 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(createDummyProduct(onboarding.getProductId(), false, false, true));
 
         onboardingService
-                .approve(onboarding.getId())
+                .approve(onboarding.getId(), approveRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create())
                 .assertFailedWith(InvalidRequestException.class);
@@ -2651,6 +2664,8 @@ class OnboardingServiceDefaultTest {
         Onboarding onboarding = createDummyOnboarding();
         onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
         PanacheMock.mock(Onboarding.class);
+        ApproveRequest approveRequest = new ApproveRequest();
+        approveRequest.setUserUid("useruid");
         when(Onboarding.findByIdOptional(any()))
                 .thenReturn(Uni.createFrom().item(Optional.of(onboarding)));
 
@@ -2663,7 +2678,7 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(true);
 
         UniAssertSubscriber<OnboardingGet> subscriber = onboardingService
-                .approve(onboarding.getId())
+                .approve(onboarding.getId(), approveRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2619,6 +2619,8 @@ class OnboardingServiceDefaultTest {
         when(Onboarding.findByIdOptional(any()))
                 .thenReturn(Uni.createFrom().item(Optional.of(onboarding)));
 
+        mockUpdateOnboarding(onboarding.getId(), 1L);
+
         when(productService.getProductIsValid(onboarding.getProductId()))
                 .thenReturn(createDummyProduct(onboarding.getProductId(), false, false, true));
 
@@ -2668,6 +2670,8 @@ class OnboardingServiceDefaultTest {
         approveRequest.setUserUid("useruid");
         when(Onboarding.findByIdOptional(any()))
                 .thenReturn(Uni.createFrom().item(Optional.of(onboarding)));
+
+        mockUpdateOnboarding(onboarding.getId(), 1L);
 
         when(productService.getProductIsValid(onboarding.getProductId()))
                 .thenReturn(createDummyProduct(onboarding.getProductId(), false, false, true));

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceIntegrationTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceIntegrationTest.java
@@ -23,6 +23,7 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.onboarding.controller.request.ReasonRequest;
 import it.pagopa.selfcare.onboarding.controller.request.UserRequest;
 import it.pagopa.selfcare.onboarding.controller.request.UserRequesterDto;
 import it.pagopa.selfcare.onboarding.entity.Institution;
@@ -296,12 +297,15 @@ class OnboardingServiceIntegrationTest {
     void testOnboardingUpdateStatusOK() {
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setUserUid("uuid");
+        reasonRequest.setReasonForReject("reason");
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
         mockUpdateOnboarding(onboarding.getId(), 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId(), "string")
+                .rejectOnboarding(onboarding.getId(), reasonRequest)
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 


### PR DESCRIPTION
## Pull Request Description

#### List of Changes

The main changes in this pull request are:

- Added a new `processedByUserUid` field to the `Onboarding` entity to keep track of the user who approved or rejected the onboarding request.
- Updated the `ApproveRequest` and `RejectRequest` APIs to include the `userUid` field.
- Implemented the logic to update the `processedByUserUid` field when approving or rejecting an onboarding request.

#### Motivation and Context

The main motivation for these changes is to improve the onboarding process by keeping track of the user who performed the approval or rejection action. This information can be useful for auditing and reporting purposes.

#### How Has This Been Tested?

These changes have been thoroughly tested using unit tests and integration tests. The unit tests ensure that the new fields are correctly updated in the `Onboarding` entity, and the integration tests verify the behavior of the updated `ApproveRequest` and `RejectRequest` APIs.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.