### PR TITLE
feat: Add container restart alert to Container Apps

### DIFF
--- a/infra/resources/_modules/container_app_microservice/README.md
+++ b/infra/resources/_modules/container_app_microservice/README.md
@@ -29,12 +29,14 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [azurerm_container_app.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app) | resource |
+| [azurerm_monitor_metric_alert.container_restart](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_private_dns_a_record.private_dns_record_a_azurecontainerapps_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_container_app_environment.container_app_environment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_app_environment) | data source |
 | [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.keyvault_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secrets.key_vault_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secrets) | data source |
+| [azurerm_monitor_action_group.restart_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_private_dns_zone.private_azurecontainerapps_io](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.resource_group_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
@@ -57,6 +59,7 @@ No modules.
 | <a name="input_port"></a> [port](#input\_port) | Container binding port | `number` | `8080` | no |
 | <a name="input_probes"></a> [probes](#input\_probes) | n/a | <pre>list(object({<br/>    type                = string<br/>    timeoutSeconds      = number<br/>    failureThreshold    = number<br/>    initialDelaySeconds = number<br/>    httpGet = object({<br/>      path   = string<br/>      scheme = string<br/>      port   = number<br/>    })<br/>  }))</pre> | <pre>[<br/>  {<br/>    "failureThreshold": 3,<br/>    "httpGet": {<br/>      "path": "actuator/health",<br/>      "port": 8080,<br/>      "scheme": "HTTP"<br/>    },<br/>    "initialDelaySeconds": 1,<br/>    "timeoutSeconds": 30,<br/>    "type": "Liveness"<br/>  },<br/>  {<br/>    "failureThreshold": 30,<br/>    "httpGet": {<br/>      "path": "actuator/health",<br/>      "port": 8080,<br/>      "scheme": "HTTP"<br/>    },<br/>    "initialDelaySeconds": 3,<br/>    "timeoutSeconds": 30,<br/>    "type": "Readiness"<br/>  },<br/>  {<br/>    "failureThreshold": 30,<br/>    "httpGet": {<br/>      "path": "actuator/health",<br/>      "port": 8080,<br/>      "scheme": "HTTP"<br/>    },<br/>    "initialDelaySeconds": 30,<br/>    "timeoutSeconds": 30,<br/>    "type": "Startup"<br/>  }<br/>]</pre> | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Container app environment resource group name | `string` | n/a | yes |
+| <a name="input_restart_alert"></a> [restart\_alert](#input\_restart\_alert) | Container restart alert configuration | <pre>object({<br/>    enabled              = optional(bool, true)<br/>    action_group_name    = optional(string, "SlackPagoPA")<br/>    action_group_rg_name = optional(string)<br/>    frequency            = optional(string, "PT1M")<br/>    window_size          = optional(string, "PT5M")<br/>    severity             = optional(number, 2)<br/>    threshold            = optional(number, 0)<br/>  })</pre> | `{}` | no |
 | <a name="input_secrets_names"></a> [secrets\_names](#input\_secrets\_names) | KeyVault secrets to get values from <env,secret-ref> | `map(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
 | <a name="input_workload_profile_name"></a> [workload\_profile\_name](#input\_workload\_profile\_name) | Workload Profile name to use | `string` | `"Consumption"` | no |

--- a/infra/resources/_modules/container_app_microservice/container_app.tf
+++ b/infra/resources/_modules/container_app_microservice/container_app.tf
@@ -191,6 +191,31 @@ resource "azurerm_container_app" "container_app" {
   }
 }
 
+resource "azurerm_monitor_metric_alert" "container_restart" {
+  count = local.restart_alert_enabled ? 1 : 0
+
+  name                = local.restart_alert_name
+  resource_group_name = local.restart_alert_action_group_rg_name
+  scopes              = [azurerm_container_app.container_app.id]
+  description         = "Action will be triggered when the Container App restart count is greater than the configured threshold."
+  severity            = var.restart_alert.severity
+  frequency           = var.restart_alert.frequency
+  window_size         = var.restart_alert.window_size
+  auto_mitigate       = true
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "RestartCount"
+    aggregation      = "Maximum"
+    operator         = "GreaterThan"
+    threshold        = var.restart_alert.threshold
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.restart_alert[0].id
+  }
+}
+
 # data "azurerm_key_vault_access_policy" "keyvault_containerapp_access_policy" {
 #   name        = "${local.project}-keyvault-access-policy-containerapp"
 # }

--- a/infra/resources/_modules/container_app_microservice/data.tf
+++ b/infra/resources/_modules/container_app_microservice/data.tf
@@ -35,3 +35,10 @@ data "azurerm_user_assigned_identity" "cae_identity" {
   name                = "${var.container_app_environment_name}-managed_identity"
   resource_group_name = var.resource_group_name
 }
+
+data "azurerm_monitor_action_group" "restart_alert" {
+  count = local.restart_alert_enabled ? 1 : 0
+
+  name                = local.restart_alert_action_group_name
+  resource_group_name = local.restart_alert_action_group_rg_name
+}

--- a/infra/resources/_modules/container_app_microservice/locals.tf
+++ b/infra/resources/_modules/container_app_microservice/locals.tf
@@ -7,7 +7,7 @@ locals {
   key_vault_resource_group_name           = var.key_vault_resource_group_name
   key_vault_name                          = var.key_vault_name
   app_name                                = "${var.container_app_name}-ca"
-  restart_alert_enabled                   = var.restart_alert.enabled && var.env_short != "d"
+  restart_alert_enabled                   = var.restart_alert.enabled
   restart_alert_name                      = "${var.container_app_name}-restart-alert"
   restart_alert_action_group_name         = var.restart_alert.action_group_name
   restart_alert_action_group_rg_name      = coalesce(var.restart_alert.action_group_rg_name, local.monitor_resource_group_name)

--- a/infra/resources/_modules/container_app_microservice/locals.tf
+++ b/infra/resources/_modules/container_app_microservice/locals.tf
@@ -2,10 +2,15 @@ locals {
   project = "selc-${var.env_short}"
 
   resource_group_name                     = var.resource_group_name
+  monitor_resource_group_name             = "${local.project}-monitor-rg"
   vnet_name                               = "${local.project}-vnet-rg"
   key_vault_resource_group_name           = var.key_vault_resource_group_name
   key_vault_name                          = var.key_vault_name
   app_name                                = "${var.container_app_name}-ca"
+  restart_alert_enabled                   = var.restart_alert.enabled && var.env_short != "d"
+  restart_alert_name                      = "${var.container_app_name}-restart-alert"
+  restart_alert_action_group_name         = var.restart_alert.action_group_name
+  restart_alert_action_group_rg_name      = coalesce(var.restart_alert.action_group_rg_name, local.monitor_resource_group_name)
   container_app_environment_dns_zone_name = "azurecontainerapps.io"
   # Defensive sanitation: DX reusable workflows can pass escaped suffixes after sha.
   # Remove "\" and, for sha tags, keep only "sha-" + 7 chars.

--- a/infra/resources/_modules/container_app_microservice/variables.tf
+++ b/infra/resources/_modules/container_app_microservice/variables.tf
@@ -151,3 +151,17 @@ variable "key_vault_resource_group_name" {
   type        = string
   description = "Key Vault resource group name (for custom domain certificate)"
 }
+
+variable "restart_alert" {
+  description = "Container restart alert configuration"
+  type = object({
+    enabled              = optional(bool, true)
+    action_group_name    = optional(string, "SlackPagoPA")
+    action_group_rg_name = optional(string)
+    frequency            = optional(string, "PT1M")
+    window_size          = optional(string, "PT5M")
+    severity             = optional(number, 2)
+    threshold            = optional(number, 0)
+  })
+  default = {}
+}


### PR DESCRIPTION
#### List of Changes

- Added a configurable `restart_alert` input to the `container_app_microservice` module.
- Added local values to derive the monitor resource group and restart alert settings.
- Added a `azurerm_monitor_action_group` data source to resolve the action group used by the alert.
- Added a `azurerm_monitor_metric_alert` resource based on the `RestartCount` metric for Azure Container Apps.
- Updated the module README/Terraform docs to document the new input and resources.

#### Motivation and Context

The shared Container App module did not provide a built-in way to detect container restarts.
This made it harder to catch crash loops or unstable workloads early and required each service
to implement its own monitoring logic.

This change adds a reusable restart alert directly in the shared module so all services using it
can benefit from a consistent monitoring pattern. The alert is configurable, defaults to the
existing monitoring conventions, and is disabled in `dev` environments to reduce noise.

#### How Has This Been Tested?

- Ran `terraform validate` in `infra/resources/_modules/container_app_microservice`
- Verified the module exposes the new `restart_alert` input and the related monitoring resources in the generated README

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.