### PR TITLE
Tune production Container App sizing

### DIFF
--- a/infra/repository/README.md
+++ b/infra/repository/README.md
@@ -23,7 +23,7 @@ Make sure your PAT has access to this repository. Then, follow these steps:
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.74.0 |
 
 ## Modules
 

--- a/infra/resources/external-api/prod-ar/locals.tf
+++ b/infra/resources/external-api/prod-ar/locals.tf
@@ -13,7 +13,11 @@ module "local" {
   private_dns_name_domain        = "lemonpond-bb0b750e.westeurope.azurecontainerapps.io"
   container_app_environment_name = "selc-p-cae-002"
   ca_resource_group_name         = "selc-p-container-app-002-rg"
-  container_app_min_replicas     = 0
+  container_app_min_replicas     = 2
+  container_app_max_replicas     = 5
+  container_app_desired_replicas = "3"
+  container_app_cpu              = 1.25
+  container_app_memory           = "2.5Gi"
 }
 
 locals {

--- a/infra/resources/external-api/prod-pnpg/locals.tf
+++ b/infra/resources/external-api/prod-pnpg/locals.tf
@@ -14,6 +14,7 @@ module "local" {
   private_dns_name_domain        = "calmmoss-0be48755.westeurope.azurecontainerapps.io"
   container_app_environment_name = "selc-p-pnpg-cae-cp"
   ca_resource_group_name         = "selc-p-container-app-rg"
+  container_app_min_replicas     = 3
   container_app_max_replicas     = 5
   container_app_desired_replicas = "3"
   container_app_cpu              = 1.25

--- a/infra/resources/onboarding-bff/prod-pnpg/main.tf
+++ b/infra/resources/onboarding-bff/prod-pnpg/main.tf
@@ -14,6 +14,7 @@ module "local" {
   private_dns_name_domain        = "calmmoss-0be48755.westeurope.azurecontainerapps.io"
   container_app_environment_name = "selc-p-pnpg-cae-cp"
   ca_resource_group_name         = "selc-p-container-app-rg"
+  container_app_min_replicas     = 2
   container_app_max_replicas     = 5
   container_app_desired_replicas = "3"
   container_app_cpu              = 1.25

--- a/infra/resources/onboarding-ms/prod-pnpg/onboarding.tf
+++ b/infra/resources/onboarding-ms/prod-pnpg/onboarding.tf
@@ -14,6 +14,7 @@ module "local" {
   private_dns_name_domain        = "calmmoss-0be48755.westeurope.azurecontainerapps.io"
   container_app_environment_name = "selc-p-pnpg-cae-cp"
   ca_resource_group_name         = "selc-p-container-app-rg"
+  container_app_min_replicas     = 2
   container_app_max_replicas     = 5
   container_app_desired_replicas = "3"
   container_app_cpu              = 1.25

--- a/infra/resources/spid-login/prod-pnpg/hub_spid_login.tf
+++ b/infra/resources/spid-login/prod-pnpg/hub_spid_login.tf
@@ -14,6 +14,7 @@ module "local" {
   private_dns_name_domain        = "calmmoss-0be48755.westeurope.azurecontainerapps.io"
   container_app_environment_name = "selc-p-pnpg-cae-cp"
   ca_resource_group_name         = "selc-p-container-app-rg"
+  container_app_min_replicas     = 2
   container_app_max_replicas     = 5
   container_app_desired_replicas = "3"
   container_app_cpu              = 1.25


### PR DESCRIPTION
#### List of Changes

- Increased `container_app_min_replicas` from `0` to `2` for `external-api` in `prod-ar`.
- Added explicit `container_app_max_replicas`, `container_app_desired_replicas`, `container_app_cpu`, and `container_app_memory` settings for `external-api` in `prod-ar`.
- Increased `container_app_min_replicas` to `3` for `external-api` in `prod-pnpg`.
- Increased `container_app_min_replicas` to `2` for `onboarding-bff`, `onboarding-ms`, and `spid-login` in `prod-pnpg`.
- Aligned production Container App sizing across the affected services to reduce configuration drift.

#### Motivation and Context

Some production workloads were configured with low or implicit baseline capacity, which can increase cold starts and reduce resilience during traffic spikes. This change makes sizing more explicit and raises the minimum number of running replicas for the affected Container Apps in production environments.

#### How Has This Been Tested?

- Reviewed the Terraform diff for the affected infrastructure definitions.
- Ran `terraform fmt -check` on the modified files.
- No local `terraform plan` or infrastructure deployment was executed.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Resolves SELC-8807
