### PR TITLE
[SELC-8710] feat: Added activatedAt for workflow INCREMENT_REGISTRATION_AGGREGATOR

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorIncrementRegistrationAggregator.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorIncrementRegistrationAggregator.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowType.AGGREGATOR;
 import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.BUILD_CONTRACT_ACTIVITY_NAME;
 import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_USERS_ACTIVITY;
+import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.STORE_ONBOARDING_ACTIVATEDAT;
 import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingString;
 import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingWorkflowString;
 
@@ -36,6 +37,7 @@ public record WorkflowExecutorIncrementRegistrationAggregator(ObjectMapper objec
         String onboardingWithInstitutionIdString = getOnboardingString(objectMapper, onboardingWorkflow.getOnboarding());
         createInstitutionAndOnboardingAggregate(ctx, onboardingWorkflow.getOnboarding(), onboardingMapper);
         ctx.callActivity(CREATE_USERS_ACTIVITY, onboardingWithInstitutionIdString, optionsRetry(), String.class).await();
+        ctx.callActivity(STORE_ONBOARDING_ACTIVATEDAT, onboardingWithInstitutionIdString, optionsRetry(), String.class).await();
         return Optional.of(OnboardingStatus.COMPLETED);
     }
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -395,6 +395,12 @@ class OnboardingFunctionsTest {
             .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
+    ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(orchestrationContext, times(2))
+            .callActivity(captorActivity.capture(), any(), any(), any());
+    assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(0));
+    assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(1));
+
     Mockito.verify(service, times(1))
             .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
@@ -412,6 +418,12 @@ class OnboardingFunctionsTest {
     // With the new batch orchestrator, we call ONBOARDINGS_AGGREGATE_BATCH_ORCHESTRATOR once
     Mockito.verify(orchestrationContext, times(1))
             .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_BATCH_ORCHESTRATOR), any(), any());
+
+    ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(orchestrationContext, times(2))
+            .callActivity(captorActivity.capture(), any(), any(), any());
+    assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(0));
+    assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(1));
 
     Mockito.verify(service, times(1))
             .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
This pull request updates the onboarding workflow for aggregators to ensure that the onboarding activation date is stored after user creation. It also adds corresponding tests to verify this new step in the process.

**Workflow enhancements:**

* The onboarding workflow now calls the `STORE_ONBOARDING_ACTIVATEDAT` activity after the `CREATE_USERS_ACTIVITY` to store the onboarding activation date for aggregators. [[1]](diffhunk://#diff-564d5963219b0be67742c9c50e140396505b1f73a8c3155a6fa3667d4a9a31d3R17) [[2]](diffhunk://#diff-564d5963219b0be67742c9c50e140396505b1f73a8c3155a6fa3667d4a9a31d3R40)

**Testing improvements:**

* Updated tests in `OnboardingFunctionsTest.java` to verify that both `CREATE_USERS_ACTIVITY` and `STORE_ONBOARDING_ACTIVATEDAT` activities are called in sequence during the aggregator onboarding process. [[1]](diffhunk://#diff-494f640995b05b793b1c9d9769643d9b7610b96327cf2125e03335fc27d3d42eR398-R403) [[2]](diffhunk://#diff-494f640995b05b793b1c9d9769643d9b7610b96327cf2125e03335fc27d3d42eR422-R427)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.