### PR TITLE
[SELC-8852] feat: Add missing fields to data model PRODUCT

### DIFF
--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
@@ -9,7 +9,6 @@ import it.pagopa.selfcare.product.model.*;
 import it.pagopa.selfcare.product.model.enums.OnboardingType;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -29,7 +28,10 @@ public interface ProductMapper {
 
   // Flattening delle Features
   @Mapping(target = "id", source = "productId")
-  @Mapping(target = "urlPublic", expression = "java(resolveUrlPublic(entity))")
+  @Mapping(
+      target = "urlPublic",
+      expression =
+          "java(mapBackOfficeConfigsProdurlBOurlPublic(entity.getBackOfficeEnvironmentConfigurations()))")
   @Mapping(target = "allowCompanyOnboarding", source = "features.allowCompanyOnboarding")
   @Mapping(target = "allowIndividualOnboarding", source = "features.allowIndividualOnboarding")
   @Mapping(target = "delegable", source = "features.delegable")
@@ -183,13 +185,6 @@ public interface ProductMapper {
         .findFirst()
         .map(BackOfficeEnvironmentConfiguration::getUrlPublic)
         .orElse(null);
-  }
-
-  default String resolveUrlPublic(Product product) {
-    if (StringUtils.isNotBlank(product.getUrlPublic())) {
-      return product.getUrlPublic();
-    }
-    return mapBackOfficeConfigsProdurlBOurlPublic(product.getBackOfficeEnvironmentConfigurations());
   }
 
   @Named("mapBackOfficeConfigsIdentityTokenAudience")

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
@@ -9,6 +9,7 @@ import it.pagopa.selfcare.product.model.*;
 import it.pagopa.selfcare.product.model.enums.OnboardingType;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -28,6 +29,8 @@ public interface ProductMapper {
 
   // Flattening delle Features
   @Mapping(target = "id", source = "productId")
+  @Mapping(target = "urlPublic", expression = "java(resolveUrlPublic(entity))")
+  @Mapping(target = "roleManagementURL", source = "roleManagementURL")
   @Mapping(target = "allowCompanyOnboarding", source = "features.allowCompanyOnboarding")
   @Mapping(target = "allowIndividualOnboarding", source = "features.allowIndividualOnboarding")
   @Mapping(target = "delegable", source = "features.delegable")
@@ -36,6 +39,7 @@ public interface ProductMapper {
       target = "requiresParentOnboarding",
       source = "features.requiresParentOnboarding")
   @Mapping(target = "parentId", source = "parentId")
+  @Mapping(target = "institutionTypesAllowed", source = "institutionTypesAllowed")
   @Mapping(target = "allowedInstitutionTaxCode", source = "features.allowedInstitutionTaxCode")
   @Mapping(target = "enabled", source = "features.enabled")
   @Mapping(target = "expirationDate", source = "features.expirationDays")
@@ -72,10 +76,6 @@ public interface ProductMapper {
       target = "urlBO",
       expression =
           "java(mapBackOfficeConfigsProdurlBOurl(entity.getBackOfficeEnvironmentConfigurations()))")
-  @Mapping(
-      target = "urlPublic",
-      expression =
-          "java(mapBackOfficeConfigsProdurlBOurlPublic(entity.getBackOfficeEnvironmentConfigurations()))")
   @Mapping(
       target = "identityTokenAudience",
       expression =
@@ -182,8 +182,15 @@ public interface ProductMapper {
     return list.stream()
         .filter(config -> config.getEnv().equalsIgnoreCase("prod"))
         .findFirst()
-        .map(BackOfficeEnvironmentConfiguration::getIdentityTokenAudience)
+        .map(BackOfficeEnvironmentConfiguration::getUrlPublic)
         .orElse(null);
+  }
+
+  default String resolveUrlPublic(Product product) {
+    if (StringUtils.isNotBlank(product.getUrlPublic())) {
+      return product.getUrlPublic();
+    }
+    return mapBackOfficeConfigsProdurlBOurlPublic(product.getBackOfficeEnvironmentConfigurations());
   }
 
   @Named("mapBackOfficeConfigsIdentityTokenAudience")

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
@@ -207,6 +207,7 @@ public interface ProductMapper {
       return null;
     }
     return list.stream()
+        .filter(config -> !config.getEnv().equalsIgnoreCase("prod"))
         .collect(
             Collectors.toMap(
                 BackOfficeEnvironmentConfiguration::getEnv, this::toBackOfficeResource));

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/mapper/ProductMapper.java
@@ -30,7 +30,6 @@ public interface ProductMapper {
   // Flattening delle Features
   @Mapping(target = "id", source = "productId")
   @Mapping(target = "urlPublic", expression = "java(resolveUrlPublic(entity))")
-  @Mapping(target = "roleManagementURL", source = "roleManagementURL")
   @Mapping(target = "allowCompanyOnboarding", source = "features.allowCompanyOnboarding")
   @Mapping(target = "allowIndividualOnboarding", source = "features.allowIndividualOnboarding")
   @Mapping(target = "delegable", source = "features.delegable")

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -22,7 +22,6 @@ public class Product {
   private String productId;
   private String parentId;
   private String alias;
-  private String urlPublic;
 
   private String title;
   private String description;

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -23,7 +23,6 @@ public class Product {
   private String parentId;
   private String alias;
   private String urlPublic;
-  private String roleManagementURL;
 
   private String title;
   private String description;

--- a/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product-cdc/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -22,6 +22,8 @@ public class Product {
   private String productId;
   private String parentId;
   private String alias;
+  private String urlPublic;
+  private String roleManagementURL;
 
   private String title;
   private String description;
@@ -47,6 +49,7 @@ public class Product {
   private List<BackOfficeEnvironmentConfiguration> backOfficeEnvironmentConfigurations;
 
   private List<String> testEnvProductIds;
+  private List<String> institutionTypesAllowed;
 
   private ProductMetadata metadata;
 

--- a/apps/product-cdc/src/main/resources/product.json
+++ b/apps/product-cdc/src/main/resources/product.json
@@ -3,7 +3,6 @@
   "parentId": "prod-xy",
   "alias": "prod-x",
  "urlPublic": "https://io.italia.it/",
-  "roleManagementURL": "https://selfcare.pagopa.it/products/prod-io-premium/roles",  
   "status": "ACTIVE",
   "title": "X",
   "description": "Offri ai cittadini i servizi del tuo ente in un unico canale",

--- a/apps/product-cdc/src/main/resources/product.json
+++ b/apps/product-cdc/src/main/resources/product.json
@@ -2,7 +2,6 @@
   "productId": "prod-x",
   "parentId": "prod-xy",
   "alias": "prod-x",
- "urlPublic": "https://io.italia.it/",
   "status": "ACTIVE",
   "title": "X",
   "description": "Offri ai cittadini i servizi del tuo ente in un unico canale",

--- a/apps/product-cdc/src/main/resources/product.json
+++ b/apps/product-cdc/src/main/resources/product.json
@@ -2,6 +2,8 @@
   "productId": "prod-x",
   "parentId": "prod-xy",
   "alias": "prod-x",
+ "urlPublic": "https://io.italia.it/",
+  "roleManagementURL": "https://selfcare.pagopa.it/products/prod-io-premium/roles",  
   "status": "ACTIVE",
   "title": "X",
   "description": "Offri ai cittadini i servizi del tuo ente in un unico canale",
@@ -265,6 +267,7 @@
       "labelKey": "scp"
     }
   ],
+  "institutionTypesAllowed": ["PSP"],
   "emailTemplates": [
     {
       "type": "IMPORT",
@@ -295,6 +298,7 @@
       "identityTokenAudience": "identity.it"
     }
   ],
+   "institutionTypesAllowed": ["PSP"],
    "testEnvProductIds": ["prod-interop-coll", "prod-interop-atst"],
    "metadata": {
     "createdAt": "2021-12-15T15:54:55.190Z",

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/ProductCdcServiceTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/ProductCdcServiceTest.java
@@ -211,19 +211,21 @@ class ProductCdcServiceTest {
 
   @Test
   void convertListToJsonBytes_shouldSerializeCorrectly() {
-    // Arrange
+    // given
     it.pagopa.selfcare.product.entity.Product p1 = new it.pagopa.selfcare.product.entity.Product();
     p1.setId("p1");
     List<it.pagopa.selfcare.product.entity.Product> list = List.of(p1);
 
-    // Act
+    // when
     byte[] bytes = productCdcService.convertListToJsonBytes(list);
 
-    // Assert
+    // then
     Assertions.assertNotNull(bytes);
     Assertions.assertTrue(bytes.length > 0);
     String json = new String(bytes);
-    Assertions.assertTrue(json.contains("\"id\" : \"p1\"")); // Check for pretty print format
+    Assertions.assertTrue(json.contains("\"id\" : \"p1\""));
+  }
+
   @Test
   void convertListToJsonBytes_shouldSerializeParentRelationshipFields() {
     // given
@@ -232,6 +234,9 @@ class ProductCdcServiceTest {
     child.setId("prod-xy");
     child.setParentId("prod-x");
     child.setRequiresParentOnboarding(true);
+    child.setUrlPublic("https://io.italia.it/");
+    child.setRoleManagementURL("https://io.italia.it/roles");
+    child.setInstitutionTypesAllowed(List.of("PSP"));
 
     // when
     byte[] bytes = productCdcService.convertListToJsonBytes(List.of(child));
@@ -239,6 +244,9 @@ class ProductCdcServiceTest {
     // then
     String json = new String(bytes);
     Assertions.assertTrue(json.contains("\"requiresParentOnboarding\" : true"));
-    Assertions.assertTrue(json.contains("\"parentId\" : \"prod-x\""));
+    Assertions.assertTrue(json.contains("\"urlPublic\" : \"https://io.italia.it/\""));
+    Assertions.assertTrue(
+        json.contains("\"roleManagementURL\" : \"https://io.italia.it/roles\""));
+    Assertions.assertTrue(json.contains("\"institutionTypesAllowed\" : [ \"PSP\" ]"));
   }
 }

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/ProductCdcServiceTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/ProductCdcServiceTest.java
@@ -235,7 +235,6 @@ class ProductCdcServiceTest {
     child.setParentId("prod-x");
     child.setRequiresParentOnboarding(true);
     child.setUrlPublic("https://io.italia.it/");
-    child.setRoleManagementURL("https://io.italia.it/roles");
     child.setInstitutionTypesAllowed(List.of("PSP"));
 
     // when
@@ -245,8 +244,6 @@ class ProductCdcServiceTest {
     String json = new String(bytes);
     Assertions.assertTrue(json.contains("\"requiresParentOnboarding\" : true"));
     Assertions.assertTrue(json.contains("\"urlPublic\" : \"https://io.italia.it/\""));
-    Assertions.assertTrue(
-        json.contains("\"roleManagementURL\" : \"https://io.italia.it/roles\""));
     Assertions.assertTrue(json.contains("\"institutionTypesAllowed\" : [ \"PSP\" ]"));
   }
 }

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
@@ -60,6 +60,12 @@ class ProductMapperTest {
       assertEquals(product.getParentId(), productEntity.getParentId());
       assertEquals("https://baseurl.it/", productEntity.getUrlPublic());
       assertEquals(
+          "https://baseurl.it/idp/selfcare/resolve-identity?id=<IdentityToken>",
+          productEntity.getUrlBO());
+      assertNotNull(productEntity.getBackOfficeEnvironmentConfigurations());
+      assertFalse(productEntity.getBackOfficeEnvironmentConfigurations().containsKey("PROD"));
+      assertTrue(productEntity.getBackOfficeEnvironmentConfigurations().containsKey("Locale"));
+      assertEquals(
           product.getInstitutionTypesAllowed(), productEntity.getInstitutionTypesAllowed());
       assertEquals(
           product.getFeatures().isRequiresParentOnboarding(),

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
@@ -58,6 +58,10 @@ class ProductMapperTest {
       assertNotNull(productEntity);
       assertEquals(product.getProductId(), productEntity.getId());
       assertEquals(product.getParentId(), productEntity.getParentId());
+      assertEquals(product.getUrlPublic(), productEntity.getUrlPublic());
+      assertEquals(product.getRoleManagementURL(), productEntity.getRoleManagementURL());
+      assertEquals(
+          product.getInstitutionTypesAllowed(), productEntity.getInstitutionTypesAllowed());
       assertEquals(
           product.getFeatures().isRequiresParentOnboarding(),
           productEntity.isRequiresParentOnboarding());

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
@@ -58,7 +58,7 @@ class ProductMapperTest {
       assertNotNull(productEntity);
       assertEquals(product.getProductId(), productEntity.getId());
       assertEquals(product.getParentId(), productEntity.getParentId());
-      assertEquals(product.getUrlPublic(), productEntity.getUrlPublic());
+      assertEquals("https://baseurl.it/", productEntity.getUrlPublic());
       assertEquals(
           product.getInstitutionTypesAllowed(), productEntity.getInstitutionTypesAllowed());
       assertEquals(

--- a/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
+++ b/apps/product-cdc/src/test/java/it/pagopa/selfcare/product/mapper/ProductMapperTest.java
@@ -59,7 +59,6 @@ class ProductMapperTest {
       assertEquals(product.getProductId(), productEntity.getId());
       assertEquals(product.getParentId(), productEntity.getParentId());
       assertEquals(product.getUrlPublic(), productEntity.getUrlPublic());
-      assertEquals(product.getRoleManagementURL(), productEntity.getRoleManagementURL());
       assertEquals(
           product.getInstitutionTypesAllowed(), productEntity.getInstitutionTypesAllowed());
       assertEquals(

--- a/apps/product/src/main/docs/openapi.json
+++ b/apps/product/src/main/docs/openapi.json
@@ -299,9 +299,6 @@
           "urlPublic" : {
             "type" : "string"
           },
-          "roleManagementURL" : {
-            "type" : "string"
-          },
           "title" : {
             "type" : "string"
           },
@@ -421,9 +418,6 @@
           "urlPublic" : {
             "type" : "string"
           },
-          "roleManagementURL" : {
-            "type" : "string"
-          },
           "title" : {
             "type" : "string"
           },
@@ -519,9 +513,6 @@
             "type" : "string"
           },
           "urlPublic" : {
-            "type" : "string"
-          },
-          "roleManagementURL" : {
             "type" : "string"
           },
           "title" : {

--- a/apps/product/src/main/docs/openapi.json
+++ b/apps/product/src/main/docs/openapi.json
@@ -296,9 +296,6 @@
           "alias" : {
             "type" : "string"
           },
-          "urlPublic" : {
-            "type" : "string"
-          },
           "title" : {
             "type" : "string"
           },
@@ -415,9 +412,6 @@
           "alias" : {
             "type" : "string"
           },
-          "urlPublic" : {
-            "type" : "string"
-          },
           "title" : {
             "type" : "string"
           },
@@ -510,9 +504,6 @@
             "type" : "string"
           },
           "alias" : {
-            "type" : "string"
-          },
-          "urlPublic" : {
             "type" : "string"
           },
           "title" : {

--- a/apps/product/src/main/docs/openapi.json
+++ b/apps/product/src/main/docs/openapi.json
@@ -296,6 +296,12 @@
           "alias" : {
             "type" : "string"
           },
+          "urlPublic" : {
+            "type" : "string"
+          },
+          "roleManagementURL" : {
+            "type" : "string"
+          },
           "title" : {
             "type" : "string"
           },
@@ -348,6 +354,12 @@
             }
           },
           "testEnvProductIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "institutionTypesAllowed" : {
             "type" : "array",
             "items" : {
               "type" : "string"
@@ -406,6 +418,12 @@
           "alias" : {
             "type" : "string"
           },
+          "urlPublic" : {
+            "type" : "string"
+          },
+          "roleManagementURL" : {
+            "type" : "string"
+          },
           "title" : {
             "type" : "string"
           },
@@ -458,6 +476,12 @@
             }
           },
           "testEnvProductIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "institutionTypesAllowed" : {
             "type" : "array",
             "items" : {
               "type" : "string"
@@ -494,6 +518,12 @@
           "alias" : {
             "type" : "string"
           },
+          "urlPublic" : {
+            "type" : "string"
+          },
+          "roleManagementURL" : {
+            "type" : "string"
+          },
           "title" : {
             "type" : "string"
           },
@@ -546,6 +576,12 @@
             }
           },
           "testEnvProductIds" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "institutionTypesAllowed" : {
             "type" : "array",
             "items" : {
               "type" : "string"

--- a/apps/product/src/main/docs/openapi.yaml
+++ b/apps/product/src/main/docs/openapi.yaml
@@ -238,6 +238,10 @@ components:
           type: string
         alias:
           type: string
+        urlPublic:
+          type: string
+        roleManagementURL:
+          type: string
         title:
           type: string
         description:
@@ -273,6 +277,10 @@ components:
           items:
             $ref: "#/components/schemas/BackOfficeEnvironmentConfiguration"
         testEnvProductIds:
+          type: array
+          items:
+            type: string
+        institutionTypesAllowed:
           type: array
           items:
             type: string
@@ -312,6 +320,10 @@ components:
           type: string
         alias:
           type: string
+        urlPublic:
+          type: string
+        roleManagementURL:
+          type: string
         title:
           type: string
         description:
@@ -347,6 +359,10 @@ components:
           items:
             $ref: "#/components/schemas/BackOfficeEnvironmentConfiguration"
         testEnvProductIds:
+          type: array
+          items:
+            type: string
+        institutionTypesAllowed:
           type: array
           items:
             type: string
@@ -372,6 +388,10 @@ components:
           type: string
         alias:
           type: string
+        urlPublic:
+          type: string
+        roleManagementURL:
+          type: string
         title:
           type: string
         description:
@@ -407,6 +427,10 @@ components:
           items:
             $ref: "#/components/schemas/BackOfficeEnvironmentConfiguration"
         testEnvProductIds:
+          type: array
+          items:
+            type: string
+        institutionTypesAllowed:
           type: array
           items:
             type: string

--- a/apps/product/src/main/docs/openapi.yaml
+++ b/apps/product/src/main/docs/openapi.yaml
@@ -240,8 +240,6 @@ components:
           type: string
         urlPublic:
           type: string
-        roleManagementURL:
-          type: string
         title:
           type: string
         description:
@@ -322,8 +320,6 @@ components:
           type: string
         urlPublic:
           type: string
-        roleManagementURL:
-          type: string
         title:
           type: string
         description:
@@ -389,8 +385,6 @@ components:
         alias:
           type: string
         urlPublic:
-          type: string
-        roleManagementURL:
           type: string
         title:
           type: string

--- a/apps/product/src/main/docs/openapi.yaml
+++ b/apps/product/src/main/docs/openapi.yaml
@@ -238,8 +238,6 @@ components:
           type: string
         alias:
           type: string
-        urlPublic:
-          type: string
         title:
           type: string
         description:
@@ -318,8 +316,6 @@ components:
           type: string
         alias:
           type: string
-        urlPublic:
-          type: string
         title:
           type: string
         description:
@@ -383,8 +379,6 @@ components:
         parentId:
           type: string
         alias:
-          type: string
-        urlPublic:
           type: string
         title:
           type: string

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -22,7 +22,6 @@ public class Product {
   private String productId;
   private String parentId;
   private String alias;
-  private String urlPublic;
 
   private String title;
   private String description;

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -23,7 +23,6 @@ public class Product {
   private String parentId;
   private String alias;
   private String urlPublic;
-  private String roleManagementURL;
 
   private String title;
   private String description;

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/Product.java
@@ -22,6 +22,8 @@ public class Product {
   private String productId;
   private String parentId;
   private String alias;
+  private String urlPublic;
+  private String roleManagementURL;
 
   private String title;
   private String description;
@@ -47,6 +49,7 @@ public class Product {
   private List<BackOfficeEnvironmentConfiguration> backOfficeEnvironmentConfigurations;
 
   private List<String> testEnvProductIds;
+  private List<String> institutionTypesAllowed;
 
   private ProductMetadata metadata;
 

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
@@ -17,7 +17,6 @@ public class ProductBaseFields {
 
   private String parentId;
   private String alias;
-  private String urlPublic;
   private String title;
   private String description;
 

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
@@ -17,6 +17,8 @@ public class ProductBaseFields {
 
   private String parentId;
   private String alias;
+  private String urlPublic;
+  private String roleManagementURL;
   private String title;
   private String description;
 
@@ -32,6 +34,7 @@ public class ProductBaseFields {
   private List<EmailTemplateConfig> emailTemplates;
   private List<BackOfficeEnvironmentConfiguration> backOfficeEnvironmentConfigurations;
   private List<String> testEnvProductIds;
+  private List<String> institutionTypesAllowed;
   private SigningConfiguration signingConfiguration;
   private List<ManagingInstitution> managingInstitutions;
   private List<WorkflowRule> workflowRules;

--- a/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
+++ b/apps/product/src/main/java/it/pagopa/selfcare/product/model/dto/base/ProductBaseFields.java
@@ -18,7 +18,6 @@ public class ProductBaseFields {
   private String parentId;
   private String alias;
   private String urlPublic;
-  private String roleManagementURL;
   private String title;
   private String description;
 


### PR DESCRIPTION

This pull request introduces new fields to the `Product` model and updates related mapping, serialization, and API documentation to support them. The main additions are `urlPublic`, `roleManagementURL`, and `institutionTypesAllowed`, which are now handled throughout the codebase, including in resource files, mappers, and OpenAPI specs.

**Model and Mapping Enhancements:**

* Added `urlPublic`, `roleManagementURL`, and `institutionTypesAllowed` fields to the `Product` model (`Product.java`), base DTO (`ProductBaseFields.java`), and entity classes, ensuring these properties are available throughout the application. [[1]](diffhunk://#diff-b16e50c13bc047637bc0b6cad0ca695e4cd160f1f2ded46c87ffb528a1fc1ce3R25-R26) [[2]](diffhunk://#diff-b16e50c13bc047637bc0b6cad0ca695e4cd160f1f2ded46c87ffb528a1fc1ce3R52) [[3]](diffhunk://#diff-9299631af8c426a7aaa3d0002ff9d174d4ea0be7835312dbded087c946825bfaR20-R21) [[4]](diffhunk://#diff-9299631af8c426a7aaa3d0002ff9d174d4ea0be7835312dbded087c946825bfaR37) [[5]](diffhunk://#diff-ac2c0907afec413c1b3f16694abc4d0e50fa89936bed13c5a6d41c2d9649a883R25-R26) [[6]](diffhunk://#diff-ac2c0907afec413c1b3f16694abc4d0e50fa89936bed13c5a6d41c2d9649a883R52)
* Updated `ProductMapper` to map the new fields, including logic to resolve `urlPublic` from either the direct field or back-office configuration, and to map `institutionTypesAllowed`. [[1]](diffhunk://#diff-de250e49becbfd1e39bf6a93141b8b097a0ded7496ffcb48fe679ada453943dfR32-R33) [[2]](diffhunk://#diff-de250e49becbfd1e39bf6a93141b8b097a0ded7496ffcb48fe679ada453943dfR42) [[3]](diffhunk://#diff-de250e49becbfd1e39bf6a93141b8b097a0ded7496ffcb48fe679ada453943dfL75-L78) [[4]](diffhunk://#diff-de250e49becbfd1e39bf6a93141b8b097a0ded7496ffcb48fe679ada453943dfL185-R195)

**API Documentation Updates:**

* Extended OpenAPI YAML and JSON specs to include the new fields for product-related endpoints, ensuring the API definition matches the updated model. [[1]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R241-R244) [[2]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R283-R286) [[3]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R323-R326) [[4]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R365-R368) [[5]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R391-R394) [[6]](diffhunk://#diff-6bc7f7ef5b0c1877c115ccbb94bd64d851dfc42b71978371be23c0943d4c1d85R433-R436) [[7]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R299-R304) [[8]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R362-R367) [[9]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R421-R426) [[10]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R484-R489) [[11]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R521-R526) [[12]](diffhunk://#diff-669838015926ac6950930f6a3d9c4c4ad12655ea414c1158ef3d778b8346c3d1R584-R589)

**Resource and Test Data Updates:**

* Updated `product.json` resource files to provide values for `urlPublic`, `roleManagementURL`, and `institutionTypesAllowed` for testing and documentation purposes. [[1]](diffhunk://#diff-d6678aa3e1c13faf685b71aa8215f8f32b1c6bd964017c8669c14990a0eb245dR5-R6) [[2]](diffhunk://#diff-d6678aa3e1c13faf685b71aa8215f8f32b1c6bd964017c8669c14990a0eb245dR270) [[3]](diffhunk://#diff-d6678aa3e1c13faf685b71aa8215f8f32b1c6bd964017c8669c14990a0eb245dR301)

**Test Coverage:**

* Enhanced unit tests to verify serialization and mapping of the new fields, ensuring they are correctly processed and included in JSON representations. [[1]](diffhunk://#diff-ab76b6a1fe21a5a21eaa3e7c06a187c5da16095add840784e6cc22e0af63f378R237-R250) [[2]](diffhunk://#diff-e6156ac322aee1dbdc8bee855a56f727f924ad881adc2645ee365c9a5f17d206R61-R64)

These changes ensure the new product fields are consistently supported across the application, API, and documentation.