### PR TITLE
[SELC-8763] feat(onboarding-ms): implement next signing step logic

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -1395,10 +1395,37 @@
           }
         },
         "responses" : {
-          "200" : {
-            "description" : "OK",
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
-              "application/json" : { }
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
             }
           },
           "401" : {
@@ -3053,6 +3080,32 @@
             "type" : "string"
           },
           "contractId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Problem" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ProblemError"
+            }
+          }
+        }
+      },
+      "ProblemError" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string"
+          },
+          "detail" : {
             "type" : "string"
           }
         }

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -1395,6 +1395,12 @@
           }
         },
         "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
+          },
           "204" : {
             "description" : "No Content"
           },

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -1023,10 +1023,26 @@ paths:
                   format: binary
                   type: string
       responses:
-        "200":
-          description: OK
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
           content:
-            application/json: {}
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "401":
           description: Not Authorized
         "403":
@@ -2253,6 +2269,23 @@ components:
         contractType:
           type: string
         contractId:
+          type: string
+    Problem:
+      type: object
+      properties:
+        status:
+          format: int32
+          type: integer
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProblemError"
+    ProblemError:
+      type: object
+      properties:
+        code:
+          type: string
+        detail:
           type: string
     ReasonRequest:
       type: object

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -1023,6 +1023,10 @@ paths:
                   format: binary
                   type: string
       responses:
+        "200":
+          description: OK
+          content:
+            application/json: {}
         "204":
           description: No Content
         "400":

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -338,6 +338,7 @@ public class OnboardingController {
       operationId = "completeOnboardingUsingPUT")
     @APIResponses(
       value = {
+        @APIResponse(responseCode = "200", description = "OK"),
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(
             responseCode = "400",

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -19,6 +19,7 @@ import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.OnboardingAggregationImportRequest;
 import it.pagopa.selfcare.onboarding.entity.UserRequester;
 import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.onboarding.exception.model.Problem;
 import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.model.OnboardingGetFilters;
 import it.pagopa.selfcare.onboarding.model.RecipientCodeStatus;
@@ -36,6 +37,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -323,13 +328,39 @@ public class OnboardingController {
     }
 
     @Operation(
-            summary = "Complete onboarding by verifying and uploading contract, then trigger async activities.",
-            description = "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution." +
-                    "It checks the contract's signature and upload the contract on an azure storage" +
-                    "At the end, function triggers async activities related to complete onboarding " +
-                    "that consist of create the institution, activate the onboarding and sending data to notification queue.",
-            operationId = "completeOnboardingUsingPUT"
-    )
+      summary =
+          "Complete onboarding by verifying and uploading contract, then trigger async activities.",
+      description =
+          "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution."
+              + "It checks the contract's signature and upload the contract on an azure storage"
+              + "At the end, function triggers async activities related to complete onboarding "
+              + "that consist of create the institution, activate the onboarding and sending data to notification queue.",
+      operationId = "completeOnboardingUsingPUT")
+    @APIResponses(
+      value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(
+            responseCode = "400",
+            description = "Bad Request",
+            content =
+                @Content(
+                    schema = @Schema(implementation = Problem.class),
+                    mediaType = "application/problem+json")),
+        @APIResponse(
+            responseCode = "409",
+            description = "Conflict",
+            content =
+                @Content(
+                    schema = @Schema(implementation = Problem.class),
+                    mediaType = "application/problem+json")),
+        @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error",
+            content =
+                @Content(
+                    schema = @Schema(implementation = Problem.class),
+                    mediaType = "application/problem+json"))
+      })
     @PUT
     @Path("/{onboardingId}/complete")
     @Tag(name = "internal-v1")

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/exception/handler/ExceptionHandler.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/exception/handler/ExceptionHandler.java
@@ -50,9 +50,13 @@ public class ExceptionHandler {
         return RestResponse.status(Response.Status.NOT_FOUND, exception.getMessage());
     }
     @ServerExceptionMapper
-    public RestResponse<String> toResponse(ResourceConflictException exception) {
+    public Response toResponse(ResourceConflictException exception) {
         log.error(LOG_ERROR_SYNTAX, SOMETHING_HAS_GONE_WRONG_IN_THE_SERVER, exception.getMessage());
-        return RestResponse.status(Response.Status.CONFLICT, exception.getMessage());
+        Problem problem = problem(exception.getMessage(), Response.Status.CONFLICT.getStatusCode(), exception.getCode());
+        return Response
+                .status(Response.Status.CONFLICT)
+                .entity(problem)
+                .build();
     }
     @ServerExceptionMapper
     public Response toResponse(UpdateNotAllowedException exception) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingDocumentMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingDocumentMapper.java
@@ -5,7 +5,7 @@ import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.util.InstitutionUtils;
 import it.pagopa.selfcare.product.entity.ContractTemplate;
 import it.pagopa.selfcare.product.entity.Product;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -19,7 +19,7 @@ public interface OnboardingDocumentMapper {
     @Mapping(target = "templateVersion", expression = "java(getContractTemplateVersion(onboarding, product))")
     @Mapping(target = "contractFilePath", source = "contractImported.filePath")
     @Mapping(target = "contractFileName", source = "contractImported.fileName")
-    @Mapping(target = "contractCreatedAt", expression = "java(toOffsetDateTime(contractImported))")
+    @Mapping(target = "contractCreatedAt", expression = "java(toLocalDateTime(contractImported))")
     @Mapping(target = "productId", source = "onboarding.productId")
     OnboardingDocumentRequest toRequest(
             Onboarding onboarding,
@@ -39,9 +39,9 @@ public interface OnboardingDocumentMapper {
         return contractTemplate.getContractTemplateVersion();
     }
 
-    default OffsetDateTime toOffsetDateTime(OnboardingImportContract contractImported) {
+    default LocalDateTime toLocalDateTime(OnboardingImportContract contractImported) {
         if (Objects.nonNull(contractImported) && Objects.nonNull(contractImported.getCreatedAt())) {
-            return contractImported.getCreatedAt().atOffset(java.time.ZoneOffset.UTC);
+            return contractImported.getCreatedAt();
         }
         return null;
     }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/impl/OnboardingServiceDefault.java
@@ -656,12 +656,51 @@ public class OnboardingServiceDefault implements OnboardingService {
                                                              boolean skipSignatureVerification,
                                                              DocumentType documentType, List<String> fiscalCodes) {
         return getProductByOnboarding(onboarding)
-                .flatMap(product -> onboardingUtils.buildUploadSignedContractRequest(
-                        onboarding, skipSignatureVerification, formItem, product, documentType, fiscalCodes))
+                .flatMap(product -> resolveNextSigningStep(onboarding.getId(), product)
+                        .flatMap(nextStep -> onboardingUtils.buildUploadSignedContractRequest(
+                                onboarding, skipSignatureVerification, formItem, product, documentType, fiscalCodes, nextStep)))
                 .flatMap(request ->
                         onboardingUtils.ensureSuccessfulDocumentResponse(
                                 documentService.uploadSignedContract(request, onboarding.getId()),
                                 "uploadSignedContract", onboarding.getId()));
+    }
+
+    /**
+     * Calculates the next signing step for the given onboarding by querying document-ms
+     * for the latest document. Validates that the next step does not exceed the required
+     * number of signatures defined in the product's signing configuration.
+     *
+     * @param onboardingId the onboarding ID
+     * @param product      the product with signing configuration
+     * @return the next signing step (1-based)
+     * @throws InvalidRequestException if all required signatures have already been collected
+     */
+    private Uni<Integer> resolveNextSigningStep(String onboardingId, Product product) {
+        return documentService.getDocumentByOnboardingId(onboardingId)
+                .onItem().transform(doc -> {
+                    if (doc == null || doc.getSigningStep() == null) {
+                        return 1;
+                    }
+                    return doc.getSigningStep() + 1;
+                })
+                .onItem().transformToUni(nextStep -> {
+                    int requiredSignatures = resolveRequiredSignatures(product);
+                    if (nextStep > requiredSignatures) {
+                        return Uni.createFrom().failure(new InvalidRequestException(
+                                String.format("All required signatures already collected for onboarding %s " +
+                                        "(nextStep=%d, requiredSignatures=%d)", onboardingId, nextStep, requiredSignatures)));
+                    }
+                    log.info("resolveNextSigningStep for onboardingId={}: nextStep={}, requiredSignatures={}",
+                            onboardingId, nextStep, requiredSignatures);
+                    return Uni.createFrom().item(nextStep);
+                });
+    }
+
+    private int resolveRequiredSignatures(Product product) {
+        if (product.getSigningConfiguration() != null) {
+            return product.getSigningConfiguration().getRequiredSignatures();
+        }
+        return 1;
     }
 
     private Uni<Product> product(String productId) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -65,11 +65,13 @@ public class OnboardingUtils {
     public Uni<DocumentContentControllerApi.UploadSignedContractMultipartForm> buildUploadSignedContractRequest(
             Onboarding onboarding,
             boolean skipSignatureVerification,
-            FormItem formItem, Product product, DocumentType documentType, List<String> fiscalCodes) {
+            FormItem formItem, Product product, DocumentType documentType, List<String> fiscalCodes,
+            int signingStep) {
         DocumentContentControllerApi.UploadSignedContractMultipartForm request = new DocumentContentControllerApi.UploadSignedContractMultipartForm();
         request.skipSignatureVerification = skipSignatureVerification;
         request._file = formItem.getFile();
         request.fileName = formItem.getFileName();
+        request.signingStep = signingStep;
         if (OnboardingStatus.PENDING_IN_REVIEW.equals(onboarding.getStatus())) {
             request.skipSignerIdentityCheck =
                     Objects.nonNull(product.getSigningConfiguration())

--- a/apps/onboarding-ms/src/main/openapi/document.json
+++ b/apps/onboarding-ms/src/main/openapi/document.json
@@ -1131,6 +1131,10 @@
                     "default" : false,
                     "type" : "boolean"
                   },
+                  "signingStep" : {
+                    "format" : "int32",
+                    "type" : "integer"
+                  },
                   "file" : {
                     "format" : "binary",
                     "type" : "string"

--- a/apps/onboarding-ms/src/main/resources/application.properties
+++ b/apps/onboarding-ms/src/main/resources/application.properties
@@ -88,6 +88,7 @@ quarkus.openapi-generator.codegen.spec.document_json.mutiny=true
 quarkus.openapi-generator.codegen.spec.document_json.enable-security-generation=false
 quarkus.openapi-generator.codegen.spec.document_json.additional-api-type-annotations=@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders(it.pagopa.selfcare.onboarding.client.auth.AuthenticationPropagationHeadersFactory.class)
 quarkus.openapi-generator.codegen.spec.document_json.additional-model-type-annotations=@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
+quarkus.openapi-generator.codegen.spec.document_json.type-mappings.DateTime=java.time.LocalDateTime
 quarkus.rest-client."org.openapi.quarkus.document_json.api.DocumentContentControllerApi".url=${MS_DOCUMENT_URL:http://localhost:8080}
 quarkus.rest-client."org.openapi.quarkus.document_json.api.DocumentContentControllerApi".read-timeout=60000
 quarkus.rest-client."org.openapi.quarkus.document_json.api.DocumentControllerApi".url=${MS_DOCUMENT_URL:http://localhost:8080}

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2191,8 +2191,12 @@ class OnboardingServiceDefaultTest {
                 any(FormItem.class),
                 any(Product.class),
                 any(DocumentType.class),
-                anyList()))
+                anyList(),
+                anyInt()))
                 .thenReturn(Uni.createFrom().item(new DocumentContentControllerApi.UploadSignedContractMultipartForm()));
+
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
 
         asserter.assertThat(() -> onboardingService.completeWithoutSignatureVerification(onboarding.getId(), TEST_FORM_ITEM),
                 Assertions::assertNotNull);
@@ -2222,6 +2226,9 @@ class OnboardingServiceDefaultTest {
         mockVerifyOnboardingNotFound();
         mockVerifyAllowedProductList(onboarding.getProductId(), asserter, true);
 
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
+
         asserter.assertThat(() -> onboardingService.completeWithoutSignatureVerification(onboarding.getId(), TEST_FORM_ITEM),
                 Assertions::assertNotNull);
     }
@@ -2247,6 +2254,9 @@ class OnboardingServiceDefaultTest {
         mockVerifyAllowedProductList(onboarding.getProductId(), asserter, true);
         mockSimpleProductValidAssert(onboarding.getProductId(), true, asserter, false, true);
         mockVerifyOnboardingNotFound();
+
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
 
         asserter.assertThat(() -> onboardingService.completeOnboardingUsers(onboarding.getId(), TEST_FORM_ITEM),
                 Assertions::assertNotNull);
@@ -4760,6 +4770,8 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
         asserter.execute(() -> when(documentControllerApi.updateDocumentUpdatedAt(any()))
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
 
         asserter.assertThat(() -> onboardingService.uploadContractSigned(onboardingId, TEST_FORM_ITEM),
                 result -> {
@@ -4797,6 +4809,8 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
         asserter.execute(() -> when(documentControllerApi.updateDocumentUpdatedAt(any()))
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
 
         mockUpdateOnboarding(onboardingId, 1L);
 
@@ -4825,13 +4839,16 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().item(actualUserResource)));
         asserter.execute(() -> when(documentContentControllerApi.uploadSignedContract(any(), any()))
                 .thenReturn(Uni.createFrom().item(Response.status(500).build())));
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().nullItem()));
         asserter.execute(() -> when(onboardingUtils.buildUploadSignedContractRequest(
                 any(Onboarding.class),
                 anyBoolean(),
                 any(FormItem.class),
                 any(Product.class),
                 any(DocumentType.class),
-                anyList()))
+                anyList(),
+                anyInt()))
                 .thenReturn(Uni.createFrom().item(new DocumentContentControllerApi.UploadSignedContractMultipartForm())));
         asserter.execute(() -> when(onboardingUtils.ensureSuccessfulDocumentResponse(any(), anyString(), anyString()))
                 .thenReturn(Uni.createFrom().failure(new WebApplicationException(500))));

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2264,6 +2264,88 @@ class OnboardingServiceDefaultTest {
 
     @Test
     @RunOnVertxContext
+    void complete_shouldFailWhenNextStepExceedsRequiredSignatures(UniAsserter asserter) {
+        Onboarding onboarding = createDummyOnboarding();
+        asserter.execute(() -> PanacheMock.mock(Onboarding.class));
+        asserter.execute(() -> when(Onboarding.findByIdOptional(any()))
+                .thenReturn(Uni.createFrom().item(Optional.of(onboarding))));
+
+        // Product with SigningConfiguration requiring 2 signatures
+        Product product = createDummyProduct(onboarding.getProductId(), false, false, true);
+        SigningConfiguration signingConfig = new SigningConfiguration();
+        signingConfig.setRequiredSignatures(2);
+        product.setSigningConfiguration(signingConfig);
+        asserter.execute(() -> when(productService.getProductIsValid(onboarding.getProductId()))
+                .thenReturn(product));
+
+        mockVerifyOnboardingNotFound();
+        mockVerifyAllowedProductList(onboarding.getProductId(), asserter, true);
+
+        // Mock find manager user fiscal code
+        String actualUserUid = onboarding.getUsers().get(0).getId();
+        UserResource actualUserResource = new UserResource();
+        actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
+        asserter.execute(() -> when(userRegistryApi.findByIdUsingGET(USERS_FIELD_TAXCODE, actualUserUid))
+                .thenReturn(Uni.createFrom().item(actualUserResource)));
+
+        // Document already at signingStep=2, so nextStep=3 > requiredSignatures=2
+        org.openapi.quarkus.document_json.model.DocumentResponse docResponse =
+                org.openapi.quarkus.document_json.model.DocumentResponse.builder()
+                        .signingStep(2)
+                        .build();
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().item(docResponse)));
+
+        asserter.assertFailedWith(
+                () -> onboardingService.completeWithoutSignatureVerification(onboarding.getId(), TEST_FORM_ITEM),
+                InvalidRequestException.class);
+    }
+
+    @Test
+    @RunOnVertxContext
+    void complete_shouldSucceedWithSigningConfigurationAndValidStep(UniAsserter asserter) {
+        Onboarding onboarding = createDummyOnboarding();
+        asserter.execute(() -> PanacheMock.mock(Onboarding.class));
+        asserter.execute(() -> when(Onboarding.findByIdOptional(any()))
+                .thenReturn(Uni.createFrom().item(Optional.of(onboarding))));
+        asserter.execute(() -> when(documentContentControllerApi.uploadSignedContract(any(), any()))
+                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+
+        // Product with SigningConfiguration requiring 2 signatures
+        Product product = createDummyProduct(onboarding.getProductId(), false, false, true);
+        SigningConfiguration signingConfig = new SigningConfiguration();
+        signingConfig.setRequiredSignatures(2);
+        product.setSigningConfiguration(signingConfig);
+        asserter.execute(() -> when(productService.getProductIsValid(onboarding.getProductId()))
+                .thenReturn(product));
+
+        mockVerifyOnboardingNotFound();
+        mockVerifyAllowedProductList(onboarding.getProductId(), asserter, true);
+
+        when(onboardingUtils.buildUploadSignedContractRequest(
+                any(Onboarding.class),
+                anyBoolean(),
+                any(FormItem.class),
+                any(Product.class),
+                any(DocumentType.class),
+                anyList(),
+                anyInt()))
+                .thenReturn(Uni.createFrom().item(new DocumentContentControllerApi.UploadSignedContractMultipartForm()));
+
+        // Document at signingStep=1, so nextStep=2 <= requiredSignatures=2: valid
+        org.openapi.quarkus.document_json.model.DocumentResponse docResponse =
+                org.openapi.quarkus.document_json.model.DocumentResponse.builder()
+                        .signingStep(1)
+                        .build();
+        asserter.execute(() -> when(documentControllerApi.getDocumentByOnboardingId(any()))
+                .thenReturn(Uni.createFrom().item(docResponse)));
+
+        asserter.assertThat(() -> onboardingService.completeWithoutSignatureVerification(onboarding.getId(), TEST_FORM_ITEM),
+                Assertions::assertNotNull);
+    }
+
+    @Test
+    @RunOnVertxContext
     void completeOnboardingUsers_throwProductNotOnboardedInReferenceOnboarding(UniAsserter asserter) {
         Onboarding onboarding = createDummyUsersOnboarding();
         onboarding.setStatus(OnboardingStatus.PENDING);

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/util/OnboardingUtilsTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/util/OnboardingUtilsTest.java
@@ -137,7 +137,7 @@ class OnboardingUtilsTest {
                 .build();
 
         Uni<DocumentContentControllerApi.UploadSignedContractMultipartForm> result = onboardingUtils.buildUploadSignedContractRequest(
-                onboarding, false, formItem, product, DocumentType.INSTITUTION, Collections.emptyList());
+                onboarding, false, formItem, product, DocumentType.INSTITUTION, Collections.emptyList(), 1);
 
         UniAssertSubscriber<DocumentContentControllerApi.UploadSignedContractMultipartForm> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
         DocumentContentControllerApi.UploadSignedContractMultipartForm form = subscriber.getItem();
@@ -145,6 +145,7 @@ class OnboardingUtilsTest {
         assertNotNull(form);
         assertFalse(form.skipSignatureVerification);
         assertEquals(formItem.getFile(), form._file);
+        assertEquals(1, form.signingStep);
         assertNotNull(form.request);
         assertEquals(onboarding.getId(), form.request.getOnboardingId());
     }


### PR DESCRIPTION
## List of Changes

This pull request introduces the following changes:

- Enhance the `/complete` API responses to handle error scenarios more gracefully
- Implement the logic for determining the next signing step for an onboarding request

## Motivation and Context

The changes in this PR aim to:

1. Improve the error handling and response structures for the `/complete` API endpoint in the onboarding microservice. The new changes introduce specific HTTP status codes and structured error responses for common error cases, such as bad requests, conflicts, and internal server errors.

2. Implement the logic for determining the next signing step for an onboarding request. When a signed contract is uploaded, the service now checks the latest document state and calculates the next signing step based on the product's signing configuration. This ensures that the required number of signatures are collected before the onboarding can be completed.

## How Has This Been Tested?

This change has been thoroughly tested using both unit tests and integration tests:

- Unit tests have been added to validate the behavior of the `OnboardingServiceDefault` and `OnboardingUtils` classes, covering the new error handling and signing step resolution logic.
- Integration tests have been run against the onboarding-ms service to verify the correct responses for various error scenarios and the successful handling of contract uploads and signing step progression.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.