### PR TITLE
[SELC-8764] feat(document): add signingStep parameter to uploadSignedContract

### DIFF
--- a/apps/document-ms/src/main/docs/openapi.json
+++ b/apps/document-ms/src/main/docs/openapi.json
@@ -1131,6 +1131,10 @@
                     "default" : false,
                     "type" : "boolean"
                   },
+                  "signingStep" : {
+                    "format" : "int32",
+                    "type" : "integer"
+                  },
                   "file" : {
                     "format" : "binary",
                     "type" : "string"

--- a/apps/document-ms/src/main/docs/openapi.yaml
+++ b/apps/document-ms/src/main/docs/openapi.yaml
@@ -869,6 +869,9 @@ paths:
                 skipSignerIdentityCheck:
                   default: false
                   type: boolean
+                signingStep:
+                  format: int32
+                  type: integer
                 file:
                   format: binary
                   type: string

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/controller/DocumentContentController.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/controller/DocumentContentController.java
@@ -260,10 +260,11 @@ public class DocumentContentController {
             @RestForm("request") @PartType(MediaType.APPLICATION_JSON) DocumentBuilderRequest request,
             @RestForm("skipSignatureVerification") @DefaultValue("false") boolean skipSignatureVerification,
             @RestForm("skipSignerIdentityCheck") @DefaultValue("false") boolean skipSignerIdentityCheck,
+            @RestForm("signingStep") int signingStep,
             @RestForm("file") InputStream file,
             @RestForm("fileName") String fileName) {
         return documentContentService.uploadSignedContract(
-                        onboardingId, request, skipSignatureVerification, file, fileName, skipSignerIdentityCheck)
+                        onboardingId, request, skipSignatureVerification, file, fileName, skipSignerIdentityCheck, signingStep)
                 .replaceWith(() -> Response.noContent().build());
     }
 }

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/model/entity/Document.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/model/entity/Document.java
@@ -39,8 +39,9 @@ public class Document extends ReactivePanacheMongoEntityBase {
 
     /**
      * Step di firma a cui questo documento corrisponde.
-     * AUTO-CALCOLATO da document-ms ad ogni upload di contratto firmato.
-     * Usato ESCLUSIVAMENTE per comporre il filename su Blob Storage.
+     * Calcolato da onboarding-ms e fornito come parametro obbligatorio
+     * nell'endpoint di upload del contratto firmato.
+     * Usato per comporre il filename su Blob Storage (es. signed_step2_contract.pdf).
      * NON usato per la logica di recupero (che si basa su createdAt DESC).
      */
     private Integer signingStep;

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/DocumentContentService.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/DocumentContentService.java
@@ -60,7 +60,8 @@ public interface DocumentContentService {
       boolean skipSignatureVerification,
       InputStream file,
       String fileName,
-      boolean skipSignerIdentityCheck);
+      boolean skipSignerIdentityCheck,
+      int signingStep);
 
     Uni<RestResponse<File>> retrieveAggregatesCsv(String onboardingId, String productId);
 }

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
@@ -368,26 +368,24 @@ public class DocumentContentServiceImpl implements DocumentContentService {
 
   @Override
   public Uni<String> uploadSignedContract(String onboardingId, DocumentBuilderRequest request, boolean skipSignatureVerification,
-                                          InputStream fileUpload, String fileName, boolean skipSignerIdentityCheck) {
+                                          InputStream fileUpload, String fileName, boolean skipSignerIdentityCheck, int signingStep) {
 
-    log.info("START - Uploading and verifying signed contract for onboardingId={}, productId={}",
-        sanitize(onboardingId), sanitize(request.getProductId()));
+    log.info("START - Uploading and verifying signed contract for onboardingId={}, productId={}, signingStep={}",
+        sanitize(onboardingId), sanitize(request.getProductId()), signingStep);
     long start = System.currentTimeMillis();
 
     return saveInputStreamToTempFile(fileUpload, fileName)
         .chain(physicalFile ->
-                resolveNextSigningStep(onboardingId)
-                    .chain(nextStep ->
-                            handleSignedContractUpload(
-                                onboardingId,
-                                request,
-                                skipSignatureVerification,
-                                physicalFile,
-                                fileName,
-                                nextStep,
-                                skipSignerIdentityCheck))
-                    .invoke(ignored -> telemetryService.trackSignedContractUploaded(onboardingId, System.currentTimeMillis() - start))
-                    .onTermination().invoke(() -> cleanupTempFile(physicalFile, onboardingId, request.getProductId())));
+                handleSignedContractUpload(
+                    onboardingId,
+                    request,
+                    skipSignatureVerification,
+                    physicalFile,
+                    fileName,
+                    signingStep,
+                    skipSignerIdentityCheck)
+                .invoke(ignored -> telemetryService.trackSignedContractUploaded(onboardingId, System.currentTimeMillis() - start))
+                .onTermination().invoke(() -> cleanupTempFile(physicalFile, onboardingId, request.getProductId())));
   }
 
     private Uni<File> saveInputStreamToTempFile(InputStream fileUpload, String fileName) {
@@ -481,26 +479,6 @@ public class DocumentContentServiceImpl implements DocumentContentService {
                 sanitize(onboardingId), sanitize(productId));
     }
 
-    /**
-     * Determina il prossimo signingStep interrogando il repository.
-     * Sfrutta findByOnboardingId già esistente (createdAt DESC).
-     * - Se non esiste documento o signingStep è null → 1 (primo upload)
-     * - Se esiste con signingStep = N → N + 1
-     */
-    private Uni<Integer> resolveNextSigningStep(String onboardingId) {
-        return documentRepository.findByOnboardingId(onboardingId)
-            .onItem().transform(latestDoc -> {
-                if (latestDoc == null || latestDoc.getSigningStep() == null) {
-                    log.info("resolveNextSigningStep for onboardingId={}: no previous signingStep found, nextStep=1",
-                            sanitize(onboardingId));
-                    return 1;
-                }
-                int nextStep = latestDoc.getSigningStep() + 1;
-                log.info("resolveNextSigningStep for onboardingId={}: latest signingStep={}, nextStep={}",
-                        sanitize(onboardingId), latestDoc.getSigningStep(), nextStep);
-                return nextStep;
-            });
-    }
 
     // ==================== Private Reactive I/O isolation methods ====================
 

--- a/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
+++ b/apps/document-ms/src/main/java/it/pagopa/selfcare/document/service/impl/DocumentContentServiceImpl.java
@@ -58,6 +58,7 @@ import static it.pagopa.selfcare.onboarding.common.DocumentType.ATTACHMENT;
 public class DocumentContentServiceImpl implements DocumentContentService {
     public static final String HTTP_HEADER_VALUE_ATTACHMENT_FILENAME = "attachment;filename=";
     private static final String FILE_NAME_AGGREGATES_CSV = "aggregates.csv";
+    private static final String PATH_SEPARATOR = "/";
 
     private final AzureBlobClient azureBlobClient;
     private final DocumentMsConfig documentMsConfig;
@@ -239,7 +240,7 @@ public class DocumentContentServiceImpl implements DocumentContentService {
 
                     String basePath = documentMsConfig.getContractPath();
                     String originalSignedPath = DocumentFileUtils.buildAndValidateContractFilePath(document.getContractSigned(), basePath, true);
-                    String originalContractPath = DocumentFileUtils.buildAndValidateContractFilePath(onboardingId + "/" + document.getContractFilename(), basePath, false);
+                    String originalContractPath = DocumentFileUtils.buildAndValidateContractFilePath(onboardingId + PATH_SEPARATOR + document.getContractFilename(), basePath, false);
 
                     String deletedSignedContract;
                     String deletedContractFile;
@@ -593,7 +594,7 @@ public class DocumentContentServiceImpl implements DocumentContentService {
             try {
                 azureBlobClient.uploadFile(ctx.storagePath, ctx.filename, Files.readAllBytes(ctx.pdfFile.toPath()));
                 return CreatePdfResponse.builder()
-                        .storagePath(ctx.storagePath + "/" + ctx.filename)
+                        .storagePath(ctx.storagePath + PATH_SEPARATOR + ctx.filename)
                         .filename(ctx.filename)
                         .build();
             } catch (IOException e) {

--- a/apps/document-ms/src/test/java/it/pagopa/selfcare/document/controller/DocumentContentControllerTest.java
+++ b/apps/document-ms/src/test/java/it/pagopa/selfcare/document/controller/DocumentContentControllerTest.java
@@ -948,7 +948,8 @@ class DocumentContentControllerTest {
                     eq(false),
                     any(InputStream.class),
                     anyString(),
-                    anyBoolean()))
+                    anyBoolean(),
+                    anyInt()))
             .thenReturn(Uni.createFrom().item("success-path")); // O .voidItem() se il service restituisce Uni<Void>
 
         File dummyFile = new File("src/test/resources/pdf/dummy.pdf");
@@ -963,6 +964,7 @@ class DocumentContentControllerTest {
                 .multiPart("fiscalCodes", "FC1") // Puoi aggiungere più multiPart con lo stesso nome per le liste
                 .multiPart("fiscalCodes", "FC2")
                 .multiPart("skipSignatureVerification", "false")
+                .multiPart("signingStep", "1")
                 .multiPart("file", dummyFile)
                 .multiPart("fileName", "filename")
                 .when()
@@ -978,7 +980,7 @@ class DocumentContentControllerTest {
 
         // SOSTITUISCI QUI: Usa InvalidRequestException invece di IllegalArgumentException
         Mockito.when(documentContentService.uploadSignedContract(
-                    any(), any(), anyBoolean(), any(), anyString(), anyBoolean()))
+                    any(), any(), anyBoolean(), any(), anyString(), anyBoolean(), anyInt()))
             .thenReturn(Uni.createFrom().failure(new InvalidRequestException("Invalid signature", "CODE-400")));
 
         File dummyFile = new File("src/test/resources/pdf/dummy.pdf");
@@ -990,6 +992,7 @@ class DocumentContentControllerTest {
                 .multiPart("productTitle", "Product Title")
                 .multiPart("institutionType", "INSTITUTION") // Modificato nome param per allinearsi al controller
                 .multiPart("contractPath", "/path/to/template")
+                .multiPart("signingStep", "1")
                 .multiPart("file", dummyFile)
                 .multiPart("fileName", "filename")
                 .when()
@@ -1004,7 +1007,7 @@ class DocumentContentControllerTest {
         String onboardingId = "onb-123";
 
         Mockito.when(documentContentService.uploadSignedContract(
-                    eq(onboardingId), any(), anyBoolean(), any(), anyString(), anyBoolean()))
+                    eq(onboardingId), any(), anyBoolean(), any(), anyString(), anyBoolean(), anyInt()))
             .thenReturn(Uni.createFrom().failure(new RuntimeException("Azure is down")));
 
         File dummyFile = new File("src/test/resources/pdf/dummy.pdf");
@@ -1014,6 +1017,7 @@ class DocumentContentControllerTest {
                 .pathParam("onboardingId", onboardingId)
                 .multiPart("productId", "prod-1")
                 .multiPart("institutionType", "INSTITUTION")
+                .multiPart("signingStep", "1")
                 .multiPart("file", dummyFile)
                 .multiPart("fileName",  "filename")
                 .when()

--- a/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentContentServiceImplTest.java
+++ b/apps/document-ms/src/test/java/it/pagopa/selfcare/document/service/DocumentContentServiceImplTest.java
@@ -1586,7 +1586,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, dummyFile, fileName, false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, dummyFile, fileName, false, 1).await();
 
         // Assert
         assertDoesNotThrow(awaiter::indefinitely);
@@ -1613,7 +1613,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false, 1).await();
 
         // Assert
         InvalidRequestException ex = assertThrows(InvalidRequestException.class, awaiter::indefinitely);
@@ -1650,7 +1650,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName, false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName, false, 1).await();
 
         // Assert
         InvalidRequestException ex = assertThrows(InvalidRequestException.class, awaiter::indefinitely);
@@ -1685,7 +1685,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false, 1).await();
 
         // Assert
         InvalidRequestException ex = assertThrows(InvalidRequestException.class, awaiter::indefinitely);
@@ -1719,7 +1719,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName, false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName, false, 1).await();
 
         // Assert
         SelfcareAzureStorageException ex = assertThrows(SelfcareAzureStorageException.class, awaiter::indefinitely);
@@ -1756,7 +1756,7 @@ class DocumentContentServiceImplTest {
 
         // Act
         var awaiter = documentContentService.uploadSignedContract(
-                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false).await();
+                ONBOARDING_ID, new DocumentBuilderRequest(), false, mockFile, fileName,false, 1).await();
 
         // Assert
         RuntimeException ex = assertThrows(RuntimeException.class, awaiter::indefinitely);

--- a/apps/document-ms/src/test/resources/features/document_content.feature
+++ b/apps/document-ms/src/test/resources/features/document_content.feature
@@ -106,6 +106,7 @@ Feature: Document content health
       | onboardingId | onb-123 |
     And The following form params:
       | request | {"onboardingId":"onb-123","productId":"prod-test","documentType":"INSTITUTION"} |
+      | signingStep | 1 |
     When I send a POST request to "/v1/document-content/{onboardingId}/upload-signed-contract" with form data only
     Then The status code is 500
 


### PR DESCRIPTION
This pull request updates the document upload flow to require the `signingStep` parameter to be explicitly provided by the client (onboarding-ms) when uploading a signed contract, instead of being auto-calculated by document-ms. This affects the API, service, and persistence layers, and updates related documentation and tests accordingly.

**API and Documentation Changes:**

- The `signingStep` parameter is now required in the `uploadSignedContract` endpoint, as reflected in the OpenAPI documentation (`openapi.yaml`, `openapi.json`). [[1]](diffhunk://#diff-f6115714b45e2b00dfc9180fa632fc31bd9bec66ffddf11e91098b29669cfe19R872-R874) [[2]](diffhunk://#diff-ff87942bb4463e2f6c25091f4b43bc5efb31402293ce996e4a528476d1804617R1134-R1137)

**Backend Implementation Changes:**

- The `DocumentContentController` and `DocumentContentService` interfaces and implementations have been updated to accept the `signingStep` parameter from the client, removing the previous auto-calculation logic. [[1]](diffhunk://#diff-7d5f46d39bf50177afedde967732f4c7a0bef6aea295191dc05604fd1b8171d3R263-R267) [[2]](diffhunk://#diff-0595205f38d82d0870138946470fb4ed02618b266a348f6c7bde07c101352303L63-R64) [[3]](diffhunk://#diff-4e4ba15bfe66f7313dd2b5ffe4c1c56e9402ee3b43013bfad95f06489bf3110fL371-R386) [[4]](diffhunk://#diff-4e4ba15bfe66f7313dd2b5ffe4c1c56e9402ee3b43013bfad95f06489bf3110fL484-L503)
- The `Document` entity's `signingStep` field documentation has been updated to clarify its new usage and source.

**Testing and Test Coverage:**

- All relevant unit and integration tests have been updated to include the required `signingStep` parameter in service calls and HTTP requests. [[1]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaL951-R952) [[2]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaR967) [[3]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaL981-R983) [[4]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaR995) [[5]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaL1007-R1010) [[6]](diffhunk://#diff-2a2f18347128d8bed4ed5871bd30dc43ddae4fa2047191a1594f71b9f762b1eaR1020) [[7]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1589-R1589) [[8]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1616-R1616) [[9]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1653-R1653) [[10]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1688-R1688) [[11]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1722-R1722) [[12]](diffhunk://#diff-8e25131b17c60b8683b9f254aa604bd3bbf8b3c24e643c0ce92fbd0cc360b5c3L1759-R1759) [[13]](diffhunk://#diff-b4776316fa8c15b08ea7e1fa7c4bb2247894fc9e017e6dcf0c3a4509425a8f66R109)

**Codebase Simplification:**

- The method for auto-calculating the next `signingStep` (`resolveNextSigningStep`) has been removed from the service implementation, simplifying the upload logic.

These changes ensure that the `signingStep` is always explicitly set by the client, improving clarity and consistency in document handling.