### PR TITLE
[selc-8901] onboarding-ms: fix Azure HTTP client dependencies

### DIFF
--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -30,6 +30,7 @@
         <common-sdk-security-version>0.2.3</common-sdk-security-version>
         <quarkus-cucumber-version>1.3.0</quarkus-cucumber-version>
         <owasp.encoder.version>1.4.0</owasp.encoder.version>
+        <azure-core-http-okhttp.version>1.12.7</azure-core-http-okhttp.version>
     </properties>
 
     <dependencyManagement>
@@ -257,6 +258,12 @@
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>selfcare-onboarding-sdk-azure-storage</artifactId>
             <version>${commons-sdk-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
@@ -267,6 +274,17 @@
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>selfcare-onboarding-sdk-product</artifactId>
             <version>${commons-sdk-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-okhttp</artifactId>
+            <version>${azure-core-http-okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>


### PR DESCRIPTION
#### List of Changes

- `apps/onboarding-ms/pom.xml`:
  - Escluso `com.azure:azure-core-http-netty` dalle dipendenze `selfcare-onboarding-sdk-azure-storage` e `selfcare-onboarding-sdk-product`.
  - Aggiunta dipendenza `com.azure:azure-core-http-okhttp:1.12.7` come implementazione alternativa dell'`HttpClientProvider` di Azure Core (selezionata automaticamente via ServiceLoader).

Nessuna modifica al codice applicativo: il provider HTTP usato da `AzureBlobClientDefault` viene risolto a runtime tramite ServiceLoader.

#### Motivation and Context

Durante un tentativo di onboarding (`POST /v1/onboarding/pa`) il microservizio `onboarding-ms` falliva con:
`java.lang.NoClassDefFoundError: Could not initialize class reactor.netty.http.client.HttpClientConfig at reactor.netty.http.client.HttpClientConnect.<init>(HttpClientConnect.java:84) at com.azure.core.http.netty.NettyAsyncHttpClientBuilder.build(NettyAsyncHttpClientBuilder.java:202) ... at it.pagopa.selfcare.azurestorage.AzureBlobClientDefault.<init>(AzureBlobClientDefault.java:63) at it.pagopa.selfcare.product.service.ProductServiceCacheable.<init>(ProductServiceCacheable.java:22) at it.pagopa.selfcare.onboarding.conf.OnboardingMsConfig.productService(OnboardingMsConfig.java:56`

Il messaggio "Could not initialize class…" indica che lo static initializer di `HttpClientConfig` era già fallito a un primo tentativo (durante l'init eager di `ProductServiceCacheable` in `OnboardingMsConfig.onStart`); ogni successivo accesso rilanciava `NoClassDefFoundError`. La causa è il conflitto fra la versione di Netty fornita da Quarkus 3.11.x e quella richiesta da `reactor-netty-http`, tirato in dote da `azure-core-http-netty` (HTTP client di default di Azure SDK).

Sostituendo il transport con `azure-core-http-okhttp` si elimina la dipendenza da `reactor-netty` e il conflitto sparisce, mantenendo intatta la compatibilità con `azure-storage-blob:12.24.0`.

#### How Has This Been Tested?

- Build locale: `mvn -f apps/onboarding-ms/pom.xml clean package -DskipTests`.
- Avvio in dev mode: `mvn -f apps/onboarding-ms/pom.xml quarkus:dev` — verificato che lo startup eager di `ProductServiceCacheable` (in `OnboardingMsConfig.onStart`) completa senza eccezioni.
- Chiamata `POST /v1/onboarding/pa` con payload valido: la richiesta non solleva più `NoClassDefFoundError` e prosegue il flusso.
- Verificato che `azure-core-http-netty` e `reactor-netty-http` non risultano più nel classpath runtime tramite `mvn -f apps/onboarding-ms/pom.xml dependency:tree`.
- Test unitari esistenti: `mvn -f apps/onboarding-ms/pom.xml test` (verde).


#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.