### PR TITLE
[SELC-8904] Delegation-CDC: Add managed identity and role for blob storage access

### DIFF
--- a/apps/delegation-cdc/pom.xml
+++ b/apps/delegation-cdc/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>delegation-cdc</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
+        <azure-data-tables.version>12.5.8</azure-data-tables.version>
+        <azure-identity.version>1.18.4</azure-identity.version>
         <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <lombok.version>1.18.28</lombok.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
@@ -20,7 +22,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.11.0</quarkus.platform.version>
+        <quarkus.platform.version>3.36.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <quarkus-openapi-generator.version>2.4.1</quarkus-openapi-generator.version>
@@ -58,7 +60,12 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-data-tables</artifactId>
-            <version>12.1.1</version>
+            <version>${azure-data-tables.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>${azure-identity.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/apps/delegation-cdc/src/main/java/it/pagopa/selfcare/delegation/event/DelegationCdcLifecycle.java
+++ b/apps/delegation-cdc/src/main/java/it/pagopa/selfcare/delegation/event/DelegationCdcLifecycle.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.delegation.event;
 
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -9,11 +10,15 @@ import jakarta.enterprise.event.Observes;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.util.Optional;
+
 @Slf4j
 @ApplicationScoped
 public class DelegationCdcLifecycle {
-    @ConfigProperty(name = "delegation-cdc.storage.connection-string") String storageConnectionString;
+    @ConfigProperty(name = "delegation-cdc.storage.connection-string") Optional<String> storageConnectionString;
     @ConfigProperty(name = "delegation-cdc.table.name") String tableName;
+    @ConfigProperty(name = "delegation-cdc.storage-account-name") Optional<String> storageAccountName;
+    @ConfigProperty(name = "delegation-cdc.managed-identity-client-id") Optional<String> managedIdentityClientId;
 
 
     void onStart(@Observes StartupEvent ev) {
@@ -26,9 +31,11 @@ public class DelegationCdcLifecycle {
         log.info("The application is starting...");
 
         // Table CdCStartAt will be created
-        TableServiceClient tableServiceClient = new TableServiceClientBuilder()
-                .connectionString(storageConnectionString)
-                .buildClient();
+        final TableServiceClient tableServiceClient = storageConnectionString
+            .filter(cs -> !cs.isBlank())
+            .map(cs -> new TableServiceClientBuilder().connectionString(cs).buildClient())
+            .orElseGet(() -> new TableServiceClientBuilder().endpoint("https://" + storageAccountName.orElse("") + ".table.core.windows.net")
+                .credential(new DefaultAzureCredentialBuilder().managedIdentityClientId(managedIdentityClientId.orElse("")).build()).buildClient());
         tableServiceClient.createTableIfNotExists(tableName);
     }
 }

--- a/apps/delegation-cdc/src/main/java/it/pagopa/selfcare/delegation/event/config/DelegationCdcConfig.java
+++ b/apps/delegation-cdc/src/main/java/it/pagopa/selfcare/delegation/event/config/DelegationCdcConfig.java
@@ -2,10 +2,13 @@ package it.pagopa.selfcare.delegation.event.config;
 
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Optional;
 
 @ApplicationScoped
 public class DelegationCdcConfig {
@@ -18,12 +21,16 @@ public class DelegationCdcConfig {
     }
 
     @ApplicationScoped
-    public TableClient tableClient(@ConfigProperty(name = "delegation-cdc.storage.connection-string") String storageConnectionString,
-                                   @ConfigProperty(name = "delegation-cdc.table.name") String tableName){
-        return new TableClientBuilder()
-                .connectionString(storageConnectionString)
-                .tableName(tableName)
-                .buildClient();
+    public TableClient tableClient(@ConfigProperty(name = "delegation-cdc.storage.connection-string") Optional<String> storageConnectionString,
+                                   @ConfigProperty(name = "delegation-cdc.table.name") String tableName,
+                                   @ConfigProperty(name = "delegation-cdc.storage-account-name") Optional<String> storageAccountName,
+                                   @ConfigProperty(name = "delegation-cdc.managed-identity-client-id") Optional<String> managedIdentityClientId){
+        return storageConnectionString
+            .filter(cs -> !cs.isBlank())
+            .map(cs -> new TableClientBuilder().connectionString(cs).tableName(tableName).buildClient())
+            .orElseGet(() -> new TableClientBuilder().endpoint("https://" + storageAccountName.orElse("") + ".table.core.windows.net")
+                .credential(new DefaultAzureCredentialBuilder().managedIdentityClientId(managedIdentityClientId.orElse("")).build())
+                .tableName(tableName).buildClient());
     }
 
 }

--- a/apps/delegation-cdc/src/main/resources/application.properties
+++ b/apps/delegation-cdc/src/main/resources/application.properties
@@ -8,7 +8,9 @@ quarkus.mongodb.database = selcMsCore
 
 delegation-cdc.appinsights.connection-string=${APPLICATIONINSIGHTS_CONNECTION_STRING:InstrumentationKey=00000000-0000-0000-0000-000000000000}
 delegation-cdc.table.name=${START_AT_TABLE_NAME:CdCStartAt}
-delegation-cdc.storage.connection-string=${STORAGE_CONNECTION_STRING:UseDevelopmentStorage=true;}
+delegation-cdc.storage.connection-string=${STORAGE_CONNECTION_STRING:}
+delegation-cdc.storage-account-name=${AZURE_STORAGE_ACCOUNT_NAME:}
+delegation-cdc.managed-identity-client-id=${AZURE_CLIENT_ID:}
 
 delegation-cdc.retry.min-backoff=${DELEGATION-CDC-RETRY-MIN-BACKOFF:10}
 delegation-cdc.retry.max-backoff=${DELEGATION-CDC-RETRY-MAX-BACKOFF:30}

--- a/infra/resources/delegation-cdc/dev-ar/main.tf
+++ b/infra/resources/delegation-cdc/dev-ar/main.tf
@@ -32,6 +32,15 @@ data "azurerm_user_assigned_identity" "cae_identity" {
 }
 
 ###############################################################################
+# RBAC
+###############################################################################
+resource "azurerm_role_assignment" "delegation_cdc_table_contributor" {
+  scope                = data.azurerm_storage_account.product_storage.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.cae_identity.principal_id
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 

--- a/infra/resources/delegation-cdc/dev-ar/main.tf
+++ b/infra/resources/delegation-cdc/dev-ar/main.tf
@@ -19,6 +19,19 @@ module "local" {
 }
 
 ###############################################################################
+# DATA SOURCES
+###############################################################################
+data "azurerm_storage_account" "product_storage" {
+  name                = "selc${module.local.config.env_short}${module.local.config.location_short}archeckoutst01"
+  resource_group_name = "selc-${module.local.config.env_short}-checkout-fe-rg"
+}
+
+data "azurerm_user_assigned_identity" "cae_identity" {
+  name                = "${module.local.config.container_app_environment_name}-managed_identity"
+  resource_group_name = module.local.config.ca_resource_group_name
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 
@@ -47,13 +60,20 @@ locals {
     {
       name  = "SHARED_ACCESS_KEY_NAME"
       value = "selfcare-wo"
+    },
+    {
+      name  = "AZURE_STORAGE_ACCOUNT_NAME"
+      value = data.azurerm_storage_account.product_storage.name
+    },
+    {
+      name  = "AZURE_CLIENT_ID"
+      value = data.azurerm_user_assigned_identity.cae_identity.client_id
     }
   ]
 
   secrets_names_delegation_cdc = {
     "APPLICATIONINSIGHTS_CONNECTION_STRING"      = "appinsights-connection-string"
     "MONGODB-CONNECTION-STRING"                  = "mongodb-connection-string"
-    "STORAGE_CONNECTION_STRING"                  = "blob-storage-product-connection-string"
     "EVENTHUB-SC-DELEGATIONS-SELFCARE-WO-KEY-LC" = "eventhub-sc-delegations-selfcare-wo-key-lc"
   }
 

--- a/infra/resources/delegation-cdc/prod-ar/main.tf
+++ b/infra/resources/delegation-cdc/prod-ar/main.tf
@@ -18,6 +18,19 @@ module "local" {
 }
 
 ###############################################################################
+# DATA SOURCES
+###############################################################################
+data "azurerm_storage_account" "product_storage" {
+  name                = "selc${module.local.config.env_short}${module.local.config.location_short}archeckoutst01"
+  resource_group_name = "selc-${module.local.config.env_short}-checkout-fe-rg"
+}
+
+data "azurerm_user_assigned_identity" "cae_identity" {
+  name                = "${module.local.config.container_app_environment_name}-managed_identity"
+  resource_group_name = module.local.config.ca_resource_group_name
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 
@@ -46,13 +59,20 @@ locals {
     {
       name  = "SHARED_ACCESS_KEY_NAME"
       value = "selfcare-wo"
+    },
+    {
+      name  = "AZURE_STORAGE_ACCOUNT_NAME"
+      value = data.azurerm_storage_account.product_storage.name
+    },
+    {
+      name  = "AZURE_CLIENT_ID"
+      value = data.azurerm_user_assigned_identity.cae_identity.client_id
     }
   ]
 
   secrets_names_delegation_cdc = {
     "APPLICATIONINSIGHTS_CONNECTION_STRING"      = "appinsights-connection-string"
     "MONGODB-CONNECTION-STRING"                  = "mongodb-connection-string"
-    "STORAGE_CONNECTION_STRING"                  = "blob-storage-product-connection-string"
     "EVENTHUB-SC-DELEGATIONS-SELFCARE-WO-KEY-LC" = "eventhub-sc-delegations-selfcare-wo-key-lc"
   }
 

--- a/infra/resources/delegation-cdc/prod-ar/main.tf
+++ b/infra/resources/delegation-cdc/prod-ar/main.tf
@@ -31,6 +31,15 @@ data "azurerm_user_assigned_identity" "cae_identity" {
 }
 
 ###############################################################################
+# RBAC
+###############################################################################
+resource "azurerm_role_assignment" "delegation_cdc_table_contributor" {
+  scope                = data.azurerm_storage_account.product_storage.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.cae_identity.principal_id
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 

--- a/infra/resources/delegation-cdc/uat-ar/main.tf
+++ b/infra/resources/delegation-cdc/uat-ar/main.tf
@@ -18,6 +18,19 @@ module "local" {
 }
 
 ###############################################################################
+# DATA SOURCES
+###############################################################################
+data "azurerm_storage_account" "product_storage" {
+  name                = "selc${module.local.config.env_short}${module.local.config.location_short}archeckoutst01"
+  resource_group_name = "selc-${module.local.config.env_short}-checkout-fe-rg"
+}
+
+data "azurerm_user_assigned_identity" "cae_identity" {
+  name                = "${module.local.config.container_app_environment_name}-managed_identity"
+  resource_group_name = module.local.config.ca_resource_group_name
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 
@@ -46,13 +59,20 @@ locals {
     {
       name  = "SHARED_ACCESS_KEY_NAME"
       value = "selfcare-wo"
+    },
+    {
+      name  = "AZURE_STORAGE_ACCOUNT_NAME"
+      value = data.azurerm_storage_account.product_storage.name
+    },
+    {
+      name  = "AZURE_CLIENT_ID"
+      value = data.azurerm_user_assigned_identity.cae_identity.client_id
     }
   ]
 
   secrets_names_delegation_cdc = {
     "APPLICATIONINSIGHTS_CONNECTION_STRING"      = "appinsights-connection-string"
     "MONGODB-CONNECTION-STRING"                  = "mongodb-connection-string"
-    "STORAGE_CONNECTION_STRING"                  = "blob-storage-product-connection-string"
     "EVENTHUB-SC-DELEGATIONS-SELFCARE-WO-KEY-LC" = "eventhub-sc-delegations-selfcare-wo-key-lc"
   }
 

--- a/infra/resources/delegation-cdc/uat-ar/main.tf
+++ b/infra/resources/delegation-cdc/uat-ar/main.tf
@@ -31,6 +31,15 @@ data "azurerm_user_assigned_identity" "cae_identity" {
 }
 
 ###############################################################################
+# RBAC
+###############################################################################
+resource "azurerm_role_assignment" "delegation_cdc_table_contributor" {
+  scope                = data.azurerm_storage_account.product_storage.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.cae_identity.principal_id
+}
+
+###############################################################################
 # Delegation CDC
 ###############################################################################
 


### PR DESCRIPTION
#### List of Changes

- Updated the application to support both connection string and managed identity authentication for Azure Table Storage by making the connection string and related properties optional and adding logic to use managed identity credentials when a connection string is not provided (`DelegationCdcLifecycle.java`, `DelegationCdcConfig.java`). [[1]](diffhunk://#diff-a447c396f558f0625c229cb6f6e8130f77dbf69fab89ead0eceac152acf4a46dR5-R21) [[2]](diffhunk://#diff-a447c396f558f0625c229cb6f6e8130f77dbf69fab89ead0eceac152acf4a46dL29-R38) [[3]](diffhunk://#diff-5859d53583b9fa463d74d283279d38dff09afff0b0674ffc76b7b0f9d87800b6R5-R12) [[4]](diffhunk://#diff-5859d53583b9fa463d74d283279d38dff09afff0b0674ffc76b7b0f9d87800b6L21-R33)

- Added new configuration properties for `storage-account-name` and `managed-identity-client-id` to support managed identity authentication (`application.properties`).

- Upgraded `azure-data-tables` and added `azure-identity` dependencies to enable managed identity support, and updated the Quarkus platform version in `pom.xml`. [[1]](diffhunk://#diff-8300134d57660b69db48b57121d0e40fd5c15d5eef2988681b185c7b2a19b5b7R15-R16) [[2]](diffhunk://#diff-8300134d57660b69db48b57121d0e40fd5c15d5eef2988681b185c7b2a19b5b7L23-R25) [[3]](diffhunk://#diff-8300134d57660b69db48b57121d0e40fd5c15d5eef2988681b185c7b2a19b5b7L61-R68)

- Added data sources and role assignments to provision the required Azure resources and grant the managed identity the "Storage Table Data Contributor" role for Table Storage in all environments (`dev-ar/main.tf`, `uat-ar/main.tf`, `prod-ar/main.tf`). [[1]](diffhunk://#diff-8e3084743e3f4aa1c377c258e708ca57b537c08494bb830074e34f8dd91c5bc1R21-R42) [[2]](diffhunk://#diff-8e3084743e3f4aa1c377c258e708ca57b537c08494bb830074e34f8dd91c5bc1R72-L56) [[3]](diffhunk://#diff-a02290e8a9cec92b86dff57706dd8161afcb7775a1200eb05f4f26e82e6ebde4R20-R41) [[4]](diffhunk://#diff-a02290e8a9cec92b86dff57706dd8161afcb7775a1200eb05f4f26e82e6ebde4R71-L55) [[5]](diffhunk://#diff-3706c6ab59d667d3c552cd63993ced2be39059888ead31d62997e795fcc30c9bR20-R41) [[6]](diffhunk://#diff-3706c6ab59d667d3c552cd63993ced2be39059888ead31d62997e795fcc30c9bR71-L55)

- Updated environment variable handling to provide the storage account name and managed identity client ID to the application, and removed the storage connection string secret from the configuration where not needed. [[1]](diffhunk://#diff-8e3084743e3f4aa1c377c258e708ca57b537c08494bb830074e34f8dd91c5bc1R72-L56) [[2]](diffhunk://#diff-a02290e8a9cec92b86dff57706dd8161afcb7775a1200eb05f4f26e82e6ebde4R71-L55) [[3]](diffhunk://#diff-3706c6ab59d667d3c552cd63993ced2be39059888ead31d62997e795fcc30c9bR71-L55)

#### Motivation and Context

This pull request updates the Delegation CDC service to support Azure Managed Identity for authentication with Azure Table Storage, improving security and flexibility. The changes include enhancements to both the Java application and the infrastructure code to enable managed identity, update dependencies, and adjust configuration handling.

These changes collectively allow the Delegation CDC service to authenticate securely with Azure Table Storage using managed identities, reducing reliance on connection strings and improving security posture.

#### How Has This Been Tested?

- Local tests
- Unit tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.