### PR TITLE
Fix Application Gateway path validation

### DIFF
--- a/infra/core/_modules/appgateway/app_gateway/main.tf
+++ b/infra/core/_modules/appgateway/app_gateway/main.tf
@@ -1,0 +1,428 @@
+data "azurerm_key_vault_secret" "client_cert" {
+  for_each     = { for t in var.trusted_client_certificates : t.secret_name => t }
+  name         = each.value.secret_name
+  key_vault_id = each.value.key_vault_id
+}
+
+resource "azurerm_application_gateway" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  zones               = var.zones
+  firewall_policy_id  = var.firewall_policy_id
+
+  sku {
+    name     = var.sku_name
+    tier     = var.sku_tier
+    capacity = var.sku_capacity
+  }
+
+  gateway_ip_configuration {
+    name      = "${var.name}-snet-conf"
+    subnet_id = var.subnet_id
+  }
+
+  frontend_ip_configuration {
+    name                 = "${var.name}-ip-conf"
+    public_ip_address_id = var.public_ip_id
+  }
+
+  dynamic "frontend_ip_configuration" {
+    for_each = var.private_ip_address
+    iterator = private
+    content {
+      name                          = "${var.name}-private-ip-conf"
+      private_ip_address            = private.value
+      private_ip_address_allocation = "Static"
+      subnet_id                     = var.subnet_id
+    }
+  }
+
+  dynamic "backend_address_pool" {
+    for_each = var.backends
+    iterator = backend
+    content {
+      name         = "${backend.key}-address-pool"
+      fqdns        = backend.value.ip_addresses == null ? backend.value.fqdns : null
+      ip_addresses = backend.value.ip_addresses
+    }
+  }
+
+  dynamic "backend_http_settings" {
+    for_each = var.backends
+    iterator = backend
+
+    content {
+      name                                = "${backend.key}-http-settings"
+      host_name                           = backend.value.host
+      cookie_based_affinity               = "Disabled"
+      affinity_cookie_name                = "ApplicationGatewayAffinity" # to avoid unwanted changes in terraform plan
+      path                                = null
+      port                                = backend.value.port
+      protocol                            = backend.value.protocol
+      request_timeout                     = backend.value.request_timeout
+      probe_name                          = backend.value.probe_name
+      pick_host_name_from_backend_address = backend.value.pick_host_name_from_backend
+      trusted_root_certificate_names      = backend.value.trusted_root_certificate_names
+    }
+  }
+
+  dynamic "probe" {
+    for_each = var.backends
+    iterator = backend
+
+    content {
+      host                                      = backend.value.host
+      minimum_servers                           = 0
+      name                                      = "probe-${backend.key}"
+      path                                      = backend.value.probe
+      pick_host_name_from_backend_http_settings = backend.value.pick_host_name_from_backend
+      protocol                                  = backend.value.protocol
+      timeout                                   = 30
+      interval                                  = 30
+      unhealthy_threshold                       = 3
+
+      match {
+        status_code = backend.value.probe_status_code
+      }
+    }
+  }
+
+  dynamic "frontend_port" {
+    for_each = distinct([for listener in values(var.listeners) : listener.port])
+
+    content {
+      name = "${var.name}-${frontend_port.value}-port"
+      port = frontend_port.value
+    }
+  }
+
+  dynamic "ssl_certificate" {
+    for_each = var.listeners
+    iterator = listener
+
+    content {
+      name                = listener.value.certificate.name
+      key_vault_secret_id = listener.value.certificate.id
+    }
+  }
+
+  dynamic "trusted_client_certificate" {
+    for_each = var.trusted_client_certificates
+    iterator = t
+    content {
+      name = t.value.secret_name
+      data = data.azurerm_key_vault_secret.client_cert[t.value.secret_name].value
+    }
+  }
+
+  dynamic "trusted_root_certificate" {
+    for_each = var.trusted_root_certificates
+    iterator = t
+    content {
+      name                = t.value.secret_name
+      key_vault_secret_id = t.value.key_vault_id
+    }
+  }
+
+  dynamic "ssl_profile" {
+    for_each = var.ssl_profiles
+    iterator = p
+    content {
+      name                             = p.value.name
+      trusted_client_certificate_names = p.value.trusted_client_certificate_names
+      verify_client_cert_issuer_dn     = p.value.verify_client_cert_issuer_dn
+      ssl_policy {
+        disabled_protocols   = p.value.ssl_policy.disabled_protocols
+        policy_type          = p.value.ssl_policy.policy_type
+        policy_name          = p.value.ssl_policy.policy_name
+        cipher_suites        = p.value.ssl_policy.cipher_suites
+        min_protocol_version = p.value.ssl_policy.min_protocol_version
+      }
+    }
+  }
+
+  dynamic "http_listener" {
+    for_each = var.listeners
+    iterator = listener
+
+    content {
+      name                           = "${listener.key}-listener"
+      frontend_ip_configuration_name = listener.value.type == "Private" ? "${var.name}-private-ip-conf" : "${var.name}-ip-conf"
+      frontend_port_name             = "${var.name}-${listener.value.port}-port"
+      protocol                       = "Https"
+      ssl_certificate_name           = listener.value.certificate.name
+      require_sni                    = true
+      host_name                      = listener.value.host
+      ssl_profile_name               = listener.value.ssl_profile_name
+      firewall_policy_id             = listener.value.firewall_policy_id
+    }
+  }
+
+  dynamic "request_routing_rule" {
+    for_each = var.routes_path_based
+    iterator = route
+
+    content {
+      name               = "${route.key}-reqs-routing-rule-by-path"
+      rule_type          = "PathBasedRouting"
+      http_listener_name = "${route.value.listener}-listener"
+      url_path_map_name  = "${route.value.url_map_name}-url-map"
+      priority           = route.value.priority
+    }
+  }
+
+  dynamic "url_path_map" {
+    for_each = var.url_path_map
+    iterator = path
+
+    content {
+      name                               = "${path.key}-url-map"
+      default_backend_address_pool_name  = "${path.value.default_backend}-address-pool"
+      default_backend_http_settings_name = "${path.value.default_backend}-http-settings"
+      default_rewrite_rule_set_name      = path.value.default_rewrite_rule_set_name
+
+      dynamic "path_rule" {
+        for_each = path.value.path_rule
+        iterator = path_rule
+
+        content {
+          name                       = path_rule.key
+          paths                      = path_rule.value.paths
+          backend_address_pool_name  = "${path_rule.value.backend}-address-pool"
+          backend_http_settings_name = "${path_rule.value.backend}-http-settings"
+          rewrite_rule_set_name      = path_rule.value.rewrite_rule_set_name
+        }
+      }
+    }
+  }
+
+  dynamic "request_routing_rule" {
+    for_each = var.routes
+    iterator = route
+
+    content {
+      #⚠️ backend_address_pool_name, backend_http_settings_name, redirect_configuration_name, and rewrite_rule_set_name are applicable only when rule_type is Basic.
+      name                       = "${route.key}-reqs-routing-rule"
+      rule_type                  = "Basic" #(Required) The Type of Routing that should be used for this Rule. Possible values are Basic and PathBasedRouting.
+      http_listener_name         = "${route.value.listener}-listener"
+      backend_address_pool_name  = "${route.value.backend}-address-pool"
+      backend_http_settings_name = "${route.value.backend}-http-settings"
+      rewrite_rule_set_name      = route.value.rewrite_rule_set_name
+      priority                   = route.value.priority
+    }
+  }
+
+  dynamic "rewrite_rule_set" {
+    for_each = var.rewrite_rule_sets
+    iterator = rule_set
+    content {
+      name = rule_set.value.name
+
+      dynamic "rewrite_rule" {
+        for_each = rule_set.value.rewrite_rules
+        content {
+          name          = rewrite_rule.value.name
+          rule_sequence = rewrite_rule.value.rule_sequence
+
+          dynamic "condition" {
+            for_each = rewrite_rule.value.conditions
+            iterator = condition
+            content {
+              variable    = condition.value.variable
+              pattern     = condition.value.pattern
+              ignore_case = condition.value.ignore_case
+              negate      = condition.value.negate
+            }
+          }
+
+          dynamic "request_header_configuration" {
+            for_each = rewrite_rule.value.request_header_configurations
+            iterator = req_header
+            content {
+              header_name  = req_header.value.header_name
+              header_value = req_header.value.header_value
+            }
+          }
+
+          dynamic "response_header_configuration" {
+            for_each = rewrite_rule.value.response_header_configurations
+            iterator = res_header
+            content {
+              header_name  = res_header.value.header_name
+              header_value = res_header.value.header_value
+            }
+          }
+
+          dynamic "url" {
+            for_each = rewrite_rule.value.url != null ? ["dummy"] : []
+
+            content {
+              path         = rewrite_rule.value.url.path
+              query_string = rewrite_rule.value.url.query_string
+              reroute      = rewrite_rule.value.url.reroute
+              components   = rewrite_rule.value.url.components
+            }
+          }
+        }
+      }
+
+    }
+  }
+
+  dynamic "custom_error_configuration" {
+    for_each = var.custom_error_configurations
+    iterator = err_conf
+
+    content {
+      status_code           = err_conf.value.status_code
+      custom_error_page_url = err_conf.value.custom_error_page_url
+    }
+  }
+
+  # see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#identity
+  identity {
+    type         = "UserAssigned"
+    identity_ids = var.identity_ids
+  }
+
+  ssl_policy {
+    policy_type = "Custom"
+    # this cipher suites are the defaults ones
+    cipher_suites = [
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    ]
+    min_protocol_version = "TLSv1_2"
+  }
+
+  dynamic "waf_configuration" {
+    for_each = var.waf_enabled ? ["dummy"] : []
+    content {
+      enabled                  = true
+      firewall_mode            = "Detection"
+      rule_set_type            = "OWASP"
+      rule_set_version         = "3.1"
+      request_body_check       = true
+      file_upload_limit_mb     = 100
+      max_request_body_size_kb = 128
+
+      dynamic "disabled_rule_group" {
+        for_each = var.waf_disabled_rule_group
+        iterator = disabled_rule_group
+
+        content {
+          rule_group_name = disabled_rule_group.value.rule_group_name
+          rules           = disabled_rule_group.value.rules
+        }
+      }
+    }
+  }
+
+  dynamic "autoscale_configuration" {
+    for_each = var.app_gateway_autoscale ? ["dummy"] : []
+    content {
+      min_capacity = var.app_gateway_min_capacity
+      max_capacity = var.app_gateway_max_capacity
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_diagnostic_setting" "app_gw" {
+  count                      = var.sec_log_analytics_workspace_id != null ? 1 : 0
+  name                       = "LogSecurity"
+  target_resource_id         = azurerm_application_gateway.this.id
+  log_analytics_workspace_id = var.sec_log_analytics_workspace_id
+  storage_account_id         = var.sec_storage_id
+
+  enabled_log {
+    category = "ApplicationGatewayAccessLog"
+  }
+
+  enabled_log {
+    category = "ApplicationGatewayFirewallLog"
+  }
+
+  enabled_log {
+    category = "ApplicationGatewayPerformanceLog"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
+}
+
+locals {
+  metric_namespace              = "Microsoft.Network/applicationgateways"
+  monitor_metric_alert_criteria = var.alerts_enabled ? var.monitor_metric_alert_criteria : {}
+}
+
+resource "azurerm_monitor_metric_alert" "this" {
+  for_each = local.monitor_metric_alert_criteria
+
+  name                = "${azurerm_application_gateway.this.name}-${upper(each.key)}"
+  description         = each.value.description
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_application_gateway.this.id]
+  frequency           = each.value.frequency
+  window_size         = each.value.window_size
+  enabled             = true
+  severity            = each.value.severity
+  auto_mitigate       = each.value.auto_mitigate
+
+  dynamic "action" {
+    for_each = var.action
+    content {
+      # action_group_id - (required) is a type of string
+      action_group_id = action.value["action_group_id"]
+      # webhook_properties - (optional) is a type of map of string
+      webhook_properties = action.value["webhook_properties"]
+    }
+  }
+
+  dynamic "criteria" {
+    for_each = each.value.criteria
+    content {
+      aggregation      = criteria.value.aggregation
+      metric_namespace = local.metric_namespace
+      metric_name      = criteria.value.metric_name
+      operator         = criteria.value.operator
+      threshold        = criteria.value.threshold
+
+      dynamic "dimension" {
+        for_each = criteria.value.dimension
+        content {
+          name     = dimension.value.name
+          operator = dimension.value.operator
+          values   = dimension.value.values
+        }
+      }
+    }
+  }
+
+  dynamic "dynamic_criteria" {
+    for_each = each.value.dynamic_criteria
+    content {
+      aggregation              = dynamic_criteria.value.aggregation
+      metric_namespace         = local.metric_namespace
+      metric_name              = dynamic_criteria.value.metric_name
+      operator                 = dynamic_criteria.value.operator
+      alert_sensitivity        = dynamic_criteria.value.alert_sensitivity
+      evaluation_total_count   = dynamic_criteria.value.evaluation_total_count
+      evaluation_failure_count = dynamic_criteria.value.evaluation_failure_count
+
+      dynamic "dimension" {
+        for_each = dynamic_criteria.value.dimension
+        content {
+          name     = dimension.value.name
+          operator = dimension.value.operator
+          values   = dimension.value.values
+        }
+      }
+    }
+  }
+  tags = var.tags
+}

--- a/infra/core/_modules/appgateway/app_gateway/outputs.tf
+++ b/infra/core/_modules/appgateway/app_gateway/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = azurerm_application_gateway.this.name
+}
+
+output "id" {
+  value = azurerm_application_gateway.this.id
+}

--- a/infra/core/_modules/appgateway/app_gateway/variables.tf
+++ b/infra/core/_modules/appgateway/app_gateway/variables.tf
@@ -1,0 +1,368 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "sku_name" {
+  type        = string
+  description = "SKU Name of the App GW"
+}
+
+variable "sku_tier" {
+  type        = string
+  description = "SKU tier of the App GW"
+}
+
+variable "sku_capacity" {
+  type        = string
+  description = "(Optional) App GW capacity. Use it only when NOT using autoscaling"
+  default     = null
+}
+
+variable "zones" {
+  type        = list(any)
+  default     = null
+  description = "(Optional) Specifies a list of Availability Zones in which this Application Gateway should be located. Changing this forces a new Application Gateway to be created."
+}
+
+# Networkig
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet dedicated to the app gateway"
+}
+
+variable "public_ip_id" {
+  type        = string
+  description = "Public IP"
+}
+
+variable "backends" {
+  type = map(object({
+    protocol                       = string                              # The Protocol which should be used. Possible values are Http and Https
+    host                           = string                              # The Hostname used for this Probe. If the Application Gateway is configured for a single site, by default the Host name should be specified as ‘127.0.0.1’, unless otherwise configured in custom probe. Cannot be set if pick_host_name_from_backend_http_settings is set to true
+    port                           = number                              # Custom port which will be used for probing the backend servers. The valid value ranges from 1 to 65535. In case not set, port from http settings will be used.
+    ip_addresses                   = list(string)                        # A list of IP Addresses which should be part of the Backend Address Pool.
+    fqdns                          = list(string)                        # A list of FQDN's which should be part of the Backend Address Pool.
+    probe                          = string                              # The Path used for this Probe.
+    probe_name                     = string                              # The Name of the Probe.
+    probe_status_code              = optional(list(string), ["200-399"]) # The status codes accepted by the probe
+    request_timeout                = number                              # The Timeout used for this Probe, which indicates when a probe becomes unhealthy. Possible values range from 1 second to a maximum of 86,400 seconds.
+    pick_host_name_from_backend    = bool                                # Whether the host header should be picked from the backend http settings
+    trusted_root_certificate_names = optional(list(string), null)        # Name of trusted root certificates, referencing the name in the trusted_root_certificates variable
+  }))
+
+  description = "Obj that allow to configure: backend_address_pool, backend_http_settings, probe"
+}
+
+variable "listeners" {
+  type = map(object({
+    protocol           = string                     # The Protocol which should be used. Possible values are Http and Https
+    host               = string                     # The Hostname which should be used for this HTTP Listener. Setting this value changes Listener Type to 'Multi site'.
+    port               = number                     # The port used for this Frontend Port.
+    ssl_profile_name   = string                     # The name of the associated SSL Profile which should be used for this HTTP Listener.
+    firewall_policy_id = string                     # The ID of the Web Application Firewall Policy which should be used for this HTTP Listener.
+    type               = optional(string, "Public") # The type of Listener "Public" - "Private"
+    certificate = object({
+      name = string # The Name of the SSL certificate that is unique within this Application Gateway
+      id   = string # Secret Id of (base-64 encoded unencrypted pfx) Secret or Certificate object stored in Azure KeyVault. You need to enable soft delete for keyvault to use this feature. Required if data is not set.
+    })
+  }))
+}
+
+variable "ssl_profiles" {
+  type = list(object({
+    name                             = string       # The name of the SSL Profile that is unique within this Application Gateway.
+    trusted_client_certificate_names = list(string) # The name of the Trusted Client Certificate that will be used to authenticate requests from clients.
+    verify_client_cert_issuer_dn     = bool         # Should client certificate issuer DN be verified? Defaults to false
+
+    ssl_policy = object({
+      disabled_protocols   = list(string)                # A list of SSL Protocols which should be disabled on this Application Gateway. Possible values are TLSv1_0, TLSv1_1 and TLSv1_2.
+      policy_type          = string                      # The Type of the Policy. Possible values are Predefined and Custom.
+      policy_name          = string                      # The Name of the Policy e.g AppGwSslPolicy20170401S. Required if policy_type is set to Predefined. Possible values can change over time and are published here https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview. Not compatible with disabled_protocols.
+      cipher_suites        = list(string)                # A List of accepted cipher suites. see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#cipher_suites for possible values
+      min_protocol_version = optional(string, "TLSv1_2") # The minimal TLS version. Possible values are TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+    })
+  }))
+  default = []
+}
+
+# Note: the attribute secret_name refers to the secret contaning the client certificate.
+# Secrects'name in the key vault can't have low hyphens but just hyphens in it.
+variable "trusted_client_certificates" {
+  type = list(object({
+    secret_name  = string # The name of the Trusted Client Certificate that is unique within this Application Gateway.
+    key_vault_id = string # Key vault id, that contains the certificate.
+  }))
+}
+
+# Note: the attribute secret_name refers to the secret contaning the client certificate.
+# Secrects'name in the key vault can't have low hyphens but just hyphens in it.
+variable "trusted_root_certificates" {
+  description = "Root certificates used to trust backend certificates"
+  type = list(object({
+    secret_name  = string # The name of the Trusted Root Certificate that is unique within this Application Gateway.
+    key_vault_id = string # Key vault id, that contains the certificate.
+  }))
+  default = []
+}
+
+variable "routes" {
+  type = map(object({
+    listener              = string # Prefix for http_listener_name
+    backend               = string # Prefix for backend_address_pool_name, backend_http_settings_name
+    rewrite_rule_set_name = string # The Name of the Rewrite Rule Set which should be used for this Routing Rule.
+    priority              = number # Rule evaluation order can be dictated by specifying an integer value from 1 to 20000 with 1 being the highest priority and 20000 being the lowest priority.
+  }))
+}
+
+variable "routes_path_based" {
+  description = "To configure path based routing"
+  type = map(object({
+    listener     = string # Prefix for http_listener_name
+    url_map_name = string # The Name of the URL Path Map which should be associated with this Routing Rule.
+    priority     = number # Rule evaluation order can be dictated by specifying an integer value from 1 to 20000 with 1 being the highest priority and 20000 being the lowest priority.
+  }))
+  default = {}
+}
+
+variable "url_path_map" {
+  type = map(object({
+    default_backend               = string # Prefix for backend_address_pool_name, backend_http_settings_name
+    default_rewrite_rule_set_name = string # The Name of the Rewrite Rule Set which should be used for this Routing Rule.
+    path_rule = map(object({
+      paths                 = list(string) # A list of Paths used in this Path Rule
+      backend               = string
+      rewrite_rule_set_name = string # The Name of the Rewrite Rule Set which should be used for this URL Path Map
+    }))
+  }))
+  default     = {}
+  description = "To configure the mapping between path and backend"
+}
+
+variable "rewrite_rule_sets" {
+  type = list(object({
+    name = string # Unique name of the rewrite rule set block
+    rewrite_rules = list(object({
+      name          = string     # Unique name of the rewrite rule block
+      rule_sequence = number     # Rule sequence of the rewrite rule that determines the order of execution in a set.
+      conditions = list(object({ # One or more condition blocks as defined above.
+        variable    = string     # The variable of the condition.
+        pattern     = string     # The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition.
+        ignore_case = bool       # Perform a case in-sensitive comparison. Defaults to false
+        negate      = bool       # Negate the result of the condition evaluation. Defaults to false
+      }))
+
+      request_header_configurations = list(object({
+        header_name  = string # Header name of the header configuration.
+        header_value = string # Header value of the header configuration. To delete a request header set this property to an empty string.
+      }))
+
+      response_header_configurations = list(object({
+        header_name  = string # Header name of the header configuration.
+        header_value = string # Header value of the header configuration. To delete a response header set this property to an empty string.
+      }))
+
+      url = object({
+        path         = string                 # The URL path to rewrite.
+        query_string = string                 # The query string to rewrite.
+        reroute      = optional(bool, false)  # Whether the URL path map should be reevaluated after this rewrite has been applied.
+        components   = optional(string, null) # The components used to rewrite the URL. Possible values are path_only and query_string_only to limit the rewrite to the URL Path or URL Query String only.
+      })
+
+    }))
+  }))
+  default     = []
+  description = "Rewrite rules sets obj descriptor"
+}
+
+# TLS
+
+variable "identity_ids" {
+  type = list(string)
+}
+
+# WAF
+
+variable "firewall_policy_id" {
+  type        = string
+  default     = null
+  description = "(Optional) Id of the WAF policy to attach to the gateway"
+}
+
+variable "waf_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable WAF"
+}
+
+variable "waf_disabled_rule_group" {
+  type = list(object({
+    rule_group_name = string       # The rule group where specific rules should be disabled.
+    rules           = list(string) # A list of rules which should be disabled in that group. Disables all rules in the specified group if rules is not specified.
+  }))
+  default = []
+}
+
+# Scaling
+
+variable "app_gateway_autoscale" {
+  type        = bool
+  description = "(Optional) Whether to activate autoscaling"
+  default     = true
+}
+
+variable "app_gateway_max_capacity" {
+  type        = string
+  description = "(Optional) Maximum capacity for autoscaling. Accepted values are in the range 2 to 125. Ignored if app_gateway_autoscale is false"
+}
+
+variable "app_gateway_min_capacity" {
+  type        = string
+  description = "(Required) Minimum capacity for autoscaling. Accepted values are in the range 0 to 100. Ignored if app_gateway_autoscale is false"
+}
+
+variable "sec_log_analytics_workspace_id" {
+  type        = string
+  default     = null
+  description = "Log analytics workspace security (it should be in a different subscription)."
+}
+
+variable "sec_storage_id" {
+  type        = string
+  default     = null
+  description = "Storage Account security (it should be in a different subscription)."
+}
+
+# Monitoring
+
+variable "alerts_enabled" {
+  type        = bool
+  default     = true
+  description = "Should Metric Alerts be enabled?"
+}
+
+variable "action" {
+  description = "The ID of the Action Group and optional map of custom string properties to include with the post webhook operation."
+  type = set(object(
+    {
+      action_group_id    = string
+      webhook_properties = map(string)
+    }
+  ))
+  default = []
+}
+
+variable "monitor_metric_alert_criteria" {
+  default = {}
+
+  description = <<EOD
+Map of name = criteria objects, see these docs for options
+https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways
+EOD
+
+  type = map(object({
+
+    description = string
+    # Possible values are PT1M, PT5M, PT15M, PT30M and PT1H
+    frequency = string
+    # Possible values are PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H and P1D.
+    window_size = string
+    # Possible values are 0, 1, 2, 3.
+    severity = number
+    # Possible values are true, false
+    auto_mitigate = bool
+
+    # static
+    criteria = list(object(
+      {
+        # criteria.*.aggregation to be one of [Average Count Minimum Maximum Total]
+        aggregation = string
+        metric_name = string
+        # criteria.0.operator to be one of [Equals NotEquals GreaterThan GreaterThanOrEqual LessThan LessThanOrEqual]
+        operator  = string
+        threshold = number
+
+        dimension = list(object(
+          {
+            name     = string
+            operator = string
+            values   = list(string)
+          }
+        ))
+      }
+    ))
+
+    # dynamic
+    dynamic_criteria = list(object(
+      {
+        # criteria.*.aggregation to be one of [Average Count Minimum Maximum Total]
+        aggregation = string
+        metric_name = string
+        # criteria.0.operator to be one of [Equals NotEquals GreaterThan GreaterThanOrEqual LessThan LessThanOrEqual]
+        operator = string
+        # Possible values are Low, Medium, High
+        alert_sensitivity = string
+
+        evaluation_total_count   = number
+        evaluation_failure_count = number
+
+        dimension = list(object(
+          {
+            name     = string
+            operator = string
+            values   = list(string)
+          }
+        ))
+      }
+    ))
+  }))
+}
+
+variable "tags" {
+  type = map(any)
+}
+
+variable "private_ip_address" {
+  type        = list(string)
+  description = "Private frontend ip"
+  default     = []
+  validation {
+    condition     = length(var.private_ip_address) <= 1
+    error_message = "Private IP address must contain at most one element"
+  }
+}
+
+variable "custom_error_configurations" {
+  type = list(object({
+    status_code           = string # HTTP status code for which to display the error page
+    custom_error_page_url = string # URL of the custom error page, must be publicly reachable
+  }))
+  default     = []
+  description = "Configurations of custom error pages for common error status codes"
+
+  validation {
+    condition = alltrue([
+      for c in var.custom_error_configurations : contains([
+        "HttpStatus400",
+        "HttpStatus403",
+        "HttpStatus404",
+        "HttpStatus405",
+        "HttpStatus408",
+        "HttpStatus500",
+        "HttpStatus502",
+        "HttpStatus503",
+        "HttpStatus504",
+      ], c.status_code)
+    ])
+    error_message = "status_code must be one of HttpStatus{400,403,404,405,408,500,502,503,504}"
+  }
+}

--- a/infra/core/_modules/appgateway/app_gateway/versions.tf
+++ b/infra/core/_modules/appgateway/app_gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4"
+    }
+  }
+}

--- a/infra/core/_modules/appgateway/main.tf
+++ b/infra/core/_modules/appgateway/main.tf
@@ -162,7 +162,7 @@ module "appgateway_snet" {
 # Application Gateway
 #
 module "app_gw" {
-  source = "github.com/pagopa/terraform-azurerm-v4.git//app_gateway?ref=v9.6.1"
+  source = "./app_gateway"
 
   resource_group_name = var.rg_vnet_name
   location            = var.rg_vnet_location


### PR DESCRIPTION
#### List of Changes

- Vendor the Application Gateway Terraform module locally under `infra/core/_modules/appgateway/app_gateway`.
- Point the existing `appgateway` wrapper module to the local module copy.
- Set `backend_http_settings.path` to `null` instead of an empty string to satisfy the AzureRM provider validation.

#### Motivation and Context

The UAT AR Terraform plan fails with AzureRM validation errors because the upstream `pagopa/terraform-azurerm-v4//app_gateway` module configures `backend_http_settings.path` as an empty string. Recent AzureRM provider versions reject that value because the path must either be omitted/null or start with `/`.

Keeping a patched local copy makes the fix persistent across `terraform init` runs and prevents Terraform from downloading the remote module version that still contains `path = ""`.

#### How Has This Been Tested?

Validated the UAT AR Terraform configuration with:

```bash
cd infra/core/uat-ar
terraform init -backend=false -upgrade
terraform validate
```

A local `terraform plan -refresh=false -lock=false` no longer reports the `backend_http_settings.*.path` validation error. The local plan is blocked later by Azure data sources that are not available in the local subscription context.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
